### PR TITLE
fix: 사용자 아트워크 조회 API 시 NPE 해결

### DIFF
--- a/src/main/java/com/example/codebase/controller/ArtworkController.java
+++ b/src/main/java/com/example/codebase/controller/ArtworkController.java
@@ -174,7 +174,7 @@ public class ArtworkController {
             @RequestParam(defaultValue = "DESC", required = false) String sortDirection
     ) {
         String loginUsername = SecurityUtil.getCurrentUsername()
-                .orElse(null);
+                .orElse("");
         boolean isAuthor = false;
         if (loginUsername.equals(username)) {
             isAuthor = true;


### PR DESCRIPTION
- loginUsername orElse 부분의 null을 ""로 바꿈