### PR TITLE
[ARTDEV-86] 회원 관련 정보 사이즈와 승인 여부 추가, 새로운 SEO 전용 API, 그외 수정 사항

### DIFF
--- a/src/main/java/com/example/codebase/controller/MemberController.java
+++ b/src/main/java/com/example/codebase/controller/MemberController.java
@@ -53,7 +53,6 @@ public class MemberController {
         return new ResponseEntity(admin, HttpStatus.CREATED);
     }
 
-
     @Operation(summary = "아티스트 정보 입력", description = "[USER] 아티스트 정보를 입력합니다.")
     @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER') and !hasAnyRole('ROLE_ARTIST', 'ROLE_CURATOR')")
     @PostMapping("/artist")
@@ -265,5 +264,21 @@ public class MemberController {
         memberService.resetPassword(code, password);
 
         return new ResponseEntity("비밀번호가 재설정 되었습니다.", HttpStatus.OK);
+    }
+
+    @Operation(summary = "이메일 수신 여부 변경", description = "[USER] 이메일 수신 여부를 변경합니다.")
+    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER')")
+    @PutMapping("/{username}/email-receive")
+    public ResponseEntity updateEmailReceive(@PathVariable String username,
+                                             @RequestParam boolean emailReceive) {
+        String currentUsername = SecurityUtil.getCurrentUsername()
+                .orElseThrow(() -> new RuntimeException("로그인이 필요합니다."));
+
+        if (!currentUsername.equals(username)) {
+            throw new RuntimeException("본인의 정보만 수정할 수 있습니다.");
+        }
+
+        String message = memberService.updateEmailReceive(username, emailReceive);
+        return new ResponseEntity(message, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/codebase/controller/MemberController.java
+++ b/src/main/java/com/example/codebase/controller/MemberController.java
@@ -281,4 +281,11 @@ public class MemberController {
         String message = memberService.updateEmailReceive(username, emailReceive);
         return new ResponseEntity(message, HttpStatus.OK);
     }
+
+    @Operation(summary = "회원 아이디 전체 조회", description = "검색엔진 노출 용 회원 아이디 리스트를 조회합니다.")
+    @GetMapping("/username")
+    public ResponseEntity getAllUsername() {
+        List<String> usernameList = memberService.getAllUsername();
+        return new ResponseEntity(usernameList, HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/example/codebase/domain/member/dto/CreateArtistMemberDTO.java
+++ b/src/main/java/com/example/codebase/domain/member/dto/CreateArtistMemberDTO.java
@@ -28,7 +28,7 @@ public class CreateArtistMemberDTO {
     @NotBlank(message = "소개를 입력해주세요.")
     private String introduction;
 
-    @Size(min = 1, max = 1000, message = "히스토리는 1~1000자 이내로 입력해주세요.")
-    @NotBlank(message = "히스토리를 입력해주세요.")
+    @Size(min = 1, max = 1000, message = "연혁은 1~1000자 이내로 입력해주세요.")
+    @NotBlank(message = "연혁을 입력해주세요.")
     private String history;
 }

--- a/src/main/java/com/example/codebase/domain/member/dto/CreateCuratorMemberDTO.java
+++ b/src/main/java/com/example/codebase/domain/member/dto/CreateCuratorMemberDTO.java
@@ -28,8 +28,8 @@ public class CreateCuratorMemberDTO {
     @NotBlank(message = "소개를 입력해주세요.")
     private String introduction;
 
-    @Size(min = 1, max = 1000, message = "히스토리는 1~1000자 이내로 입력해주세요.")
-    @NotBlank(message = "히스토리를 입력해주세요.")
+    @Size(min = 1, max = 1000, message = "연혁은 1~1000자 이내로 입력해주세요.")
+    @NotBlank(message = "연혁을 입력해주세요.")
     private String history;
 
     @Size(min = 1, max = 100, message = "회사명은 1~100자 이내로 입력해주세요.")

--- a/src/main/java/com/example/codebase/domain/member/dto/CreateMemberDTO.java
+++ b/src/main/java/com/example/codebase/domain/member/dto/CreateMemberDTO.java
@@ -1,5 +1,6 @@
 package com.example.codebase.domain.member.dto;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -24,4 +25,7 @@ public class CreateMemberDTO {
     @NotBlank(message = "이메일은 필수 입력입니다.")
     @Email(message = "이메일 형식이 올바르지 않습니다.", regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}$")
     private String email;
+
+    @NotNull(message = "이메일 수신 여부는 필수 입력입니다. (true/false)")
+    private Boolean allowEmailReceive;
 }

--- a/src/main/java/com/example/codebase/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/example/codebase/domain/member/dto/MemberResponseDTO.java
@@ -37,6 +37,11 @@ public class MemberResponseDTO {
 
     private String companyRole;
 
+    private Boolean allowEmailReceive;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime allowEmailReceiveDateTime;
+
 //    private Set<String> authrities;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
@@ -74,6 +79,9 @@ public class MemberResponseDTO {
         dto.setCompanyName(
             member.getCompanyName() != null ? member.getCompanyName() : null);
         dto.setCompanyRole(member.getCompanyRole() != null ? member.getCompanyRole() : null);
+
+        dto.setAllowEmailReceive(member.isAllowEmailReceive());
+        dto.setAllowEmailReceiveDateTime(member.getAllowEmailReceiveDatetime());
 
         return dto;
     }

--- a/src/main/java/com/example/codebase/domain/member/dto/UpdateMemberDTO.java
+++ b/src/main/java/com/example/codebase/domain/member/dto/UpdateMemberDTO.java
@@ -24,20 +24,20 @@ public class UpdateMemberDTO {
     private String email;
 
     @Parameter(required = false)
-    @Size(min = 1, max = 120, message = "주소는 1~120자 이내로 입력해주세요.")
+    @Size(min = 1, max = 120, message = "SNS 주소는 1~120자 이내로 입력해주세요.")
     @Pattern(regexp = "^(http|https)://.*", message = "SNS 주소를 입력해주세요.")
     private String snsUrl;
 
     @Parameter(required = false)
-    @Size(min = 1, max = 120, message = "주소는 1~120자 이내로 입력해주세요.")
+    @Size(min = 1, max = 120, message = "사이트 주소는 1~120자 이내로 입력해주세요.")
     @Pattern(regexp = "^(http|https)://.*", message = "웹사이트 주소를 입력해주세요.")
     private String websiteUrl;
 
     @Parameter(required = false)
-    @Size(min = 1, max = 250, message = "소개는 1~250자 이내로 입력해주세요.")
+    @Size(min = 1, max = 1000, message = "소개는 1~1000자 이내로 입력해주세요.")
     private String introduction;
 
     @Parameter(required = false)
-    @Size(min = 1, max = 250, message = "히스토리는 1~250자 이내로 입력해주세요.")
+    @Size(min = 1, max = 1000, message = "히스토리는 1~1000자 이내로 입력해주세요.")
     private String history;
 }

--- a/src/main/java/com/example/codebase/domain/member/dto/UpdateMemberDTO.java
+++ b/src/main/java/com/example/codebase/domain/member/dto/UpdateMemberDTO.java
@@ -38,6 +38,6 @@ public class UpdateMemberDTO {
     private String introduction;
 
     @Parameter(required = false)
-    @Size(min = 1, max = 1000, message = "히스토리는 1~1000자 이내로 입력해주세요.")
+    @Size(min = 1, max = 1000, message = "연혁은 1~1000자 이내로 입력해주세요.")
     private String history;
 }

--- a/src/main/java/com/example/codebase/domain/member/entity/Member.java
+++ b/src/main/java/com/example/codebase/domain/member/entity/Member.java
@@ -5,6 +5,7 @@ import com.example.codebase.domain.artwork.entity.Artwork;
 import com.example.codebase.domain.auth.OAuthAttributes;
 import com.example.codebase.domain.member.dto.CreateArtistMemberDTO;
 import com.example.codebase.domain.member.dto.CreateCuratorMemberDTO;
+import com.example.codebase.domain.member.dto.CreateMemberDTO;
 import com.example.codebase.domain.member.dto.UpdateMemberDTO;
 import com.example.codebase.domain.member.entity.oauth2.oAuthProvider;
 import com.example.codebase.domain.post.entity.Post;
@@ -76,6 +77,12 @@ public class Member {
 
     @Column(name = "company_name")
     private String companyName;
+
+    @Column(name = "allow_email_receive")
+    private boolean allowEmailReceive;
+
+    @Column(name = "allow_email_receive_datetime")
+    private LocalDateTime allowEmailReceiveDatetime;
 
     @Column(name = "created_time", nullable = false)
     private LocalDateTime createdTime;
@@ -158,6 +165,22 @@ public class Member {
         username.append(last);
 
         return username.toString();
+    }
+
+    public static Member create(PasswordEncoder passwordEncoder, CreateMemberDTO member) {
+        Member createMember = Member.builder()
+                .username(member.getUsername())
+                .password(passwordEncoder.encode(member.getPassword()))
+                .name(member.getName())
+                .email(member.getEmail())
+                .createdTime(LocalDateTime.now())
+                .updatedTime(LocalDateTime.now())
+                .allowEmailReceive(member.getAllowEmailReceive())
+                .activated(false)
+                .build();
+
+        createMember.allowEmailReceiveDatetime = member.getAllowEmailReceive() ? LocalDateTime.now() : null;
+        return createMember;
     }
 
     public void setPassword(String password) {
@@ -273,5 +296,12 @@ public class Member {
 
     public boolean isSubmitedRoleInformation() {
         return this.roleStatus == RoleStatus.ARTIST_PENDING || this.roleStatus == RoleStatus.CURATOR_PENDING || this.roleStatus == RoleStatus.ARTIST || this.roleStatus == RoleStatus.CURATOR;
+    }
+
+    public void updateEmailReceive(boolean emailReceive) {
+        LocalDateTime updateTime = LocalDateTime.now();
+        this.allowEmailReceive = emailReceive;
+        this.allowEmailReceiveDatetime = updateTime;
+        this.updatedTime = updateTime;
     }
 }

--- a/src/main/java/com/example/codebase/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/codebase/domain/member/repository/MemberRepository.java
@@ -51,4 +51,6 @@ public interface MemberRepository extends JpaRepository<Member, UUID> {
     @Query("SELECT m FROM Member m WHERE m.roleStatus = ?1 OR m.roleStatus = ?2")
     Page<Member> findAllByRoleStatus(RoleStatus pending1, RoleStatus pending2, Pageable pageable);
 
+    @Query("SELECT m.username FROM Member m WHERE m.activated = true")
+    List<String> findAllUsername();
 }

--- a/src/main/java/com/example/codebase/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/codebase/domain/member/service/MemberService.java
@@ -341,4 +341,8 @@ public class MemberService {
         String allow = emailReceive ? "동의" : "거부";
         return "이메일 수신 여부가 " + member.getAllowEmailReceiveDatetime() + " 기준 " +  allow + "로 변경되었습니다.";
     }
+
+    public List<String> getAllUsername() {
+        return memberRepository.findAllUsername();
+    }
 }

--- a/src/main/java/com/example/codebase/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/codebase/domain/member/service/MemberService.java
@@ -65,15 +65,7 @@ public class MemberService {
 
         Authority authority = Authority.builder().authorityName("ROLE_GUEST").build();
 
-        Member newMember =
-                Member.builder()
-                        .username(member.getUsername())
-                        .password(passwordEncoder.encode(member.getPassword()))
-                        .name(member.getName())
-                        .email(member.getEmail())
-                        .createdTime(LocalDateTime.now())
-                        .activated(false)
-                        .build();
+        Member newMember = Member.create(passwordEncoder, member);
 
         MemberAuthority memberAuthority =
                 MemberAuthority.builder().authority(authority).member(newMember).build();
@@ -337,5 +329,16 @@ public class MemberService {
 
         String newPasswordEncoded = passwordEncoder.encode(newPassword);
         member.updatePassword(newPasswordEncoded);
+    }
+
+    @Transactional
+    public String updateEmailReceive(String username, boolean emailReceive) {
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(NotFoundMemberException::new);
+
+        member.updateEmailReceive(emailReceive);
+
+        String allow = emailReceive ? "동의" : "거부";
+        return "이메일 수신 여부가 " + member.getAllowEmailReceiveDatetime() + " 기준 " +  allow + "로 변경되었습니다.";
     }
 }

--- a/src/main/resources/db/migration/V202312081539__add_allow_email_receive_column_to_member.sql
+++ b/src/main/resources/db/migration/V202312081539__add_allow_email_receive_column_to_member.sql
@@ -1,0 +1,3 @@
+ALTER TABLE member
+    ADD COLUMN allow_email_receive BOOLEAN NOT NULL DEFAULT FALSE
+    ADD COLUMN allow_email_receive_datetime TIMESTAMP;

--- a/src/test/java/com/example/codebase/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/MemberControllerTest.java
@@ -586,4 +586,20 @@ class MemberControllerTest {
                 .andExpect(status().isOk());
     }
 
+    @DisplayName("회원 아이디 전체 조회 시")
+    @Test
+    void 회원_아이디_전체_조회() throws Exception {
+        createOrLoadMember(1);
+        createOrLoadMember(2);
+        createOrLoadMember(3);
+        createOrLoadMember(4);
+
+        mockMvc
+                .perform(
+                        get("/api/members/username")
+                )
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
 }

--- a/src/test/java/com/example/codebase/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/MemberControllerTest.java
@@ -117,6 +117,8 @@ class MemberControllerTest {
                         .companyName("company" + index)
                         .roleStatus(role)
                         .activated(true)
+                        .allowEmailReceive(true)
+                        .allowEmailReceiveDatetime(LocalDateTime.now())
                         .createdTime(LocalDateTime.now().plusSeconds(index))
                         .build();
 
@@ -142,6 +144,7 @@ class MemberControllerTest {
         dto.setName("test1");
         dto.setUsername("test213");
         dto.setPassword("1234");
+        dto.setAllowEmailReceive(true);
 
         mockMvc.perform(
                         post("/api/members")
@@ -161,6 +164,7 @@ class MemberControllerTest {
         dto.setName("test");
         dto.setUsername("test23");
         dto.setPassword("1234");
+        dto.setAllowEmailReceive(true);
 
         mockMvc.perform(
                         post("/api/members/admin")
@@ -558,6 +562,28 @@ class MemberControllerTest {
                 )
                 .andDo(print())
                 .andExpect(status().isBadRequest());
+    }
+
+    @DisplayName("이메일 수신 여부 변경 후 내 정보 조회")
+    @WithMockCustomUser(username = "testid1", role = "USER")
+    @Test
+    void 이메일_수신_여부_변경() throws Exception {
+        Member member = createOrLoadMember();
+
+        mockMvc
+                .perform(
+                        put("/api/members/" + member.getUsername() +"/email-receive")
+                                .param("emailReceive", "true")
+                )
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        mockMvc
+                .perform(
+                        get("/api/members/" + member.getUsername())
+                )
+                .andDo(print())
+                .andExpect(status().isOk());
     }
 
 }


### PR DESCRIPTION
- 회원 정보 수정 시 history size와 가입 시 size가 상이하므로 통일 (수정 : 250자, 가입 : 1000자)
- 회원 가입 시 이메일 수신 여부 받습니다.
  - 이메일 수신 여부를 변경할 수 있는 API가 새롭게 추가됩니다. 
- 검색 엔진 용 username 리스트 조회 API 가 새롭게 추가됩니다.

자세한 구현 내용은 [Jira Ticket](https://mediaxi.atlassian.net/jira/software/projects/ARTDEV/boards/1?selectedIssue=ARTDEV-86)을 참고해주세요