### PR TITLE
비밀번호 재설정 API 이전 비밀번호 검증 로직 추가 및 내부 구현 수정

### DIFF
--- a/src/main/java/com/example/codebase/controller/MemberController.java
+++ b/src/main/java/com/example/codebase/controller/MemberController.java
@@ -259,7 +259,7 @@ public class MemberController {
     @Operation(summary = "비밀번호 재설정", description = "비밀번호 재설정 합니다.")
     @PostMapping("/reset-password")
     public ResponseEntity resetPassword(@RequestParam @NotBlank String code,
-                                        @RequestBody @NotBlank String password) {
+                                        @RequestBody PasswordResetRequestDTO password) {
 
         memberService.resetPassword(code, password);
 

--- a/src/main/java/com/example/codebase/domain/member/dto/PasswordResetRequestDTO.java
+++ b/src/main/java/com/example/codebase/domain/member/dto/PasswordResetRequestDTO.java
@@ -1,0 +1,8 @@
+package com.example.codebase.domain.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+public record PasswordResetRequestDTO (@NotBlank String oldPassword,
+                                       @NotBlank String newPassword) {}


### PR DESCRIPTION
- 비밀번호 재설정 시 이전 비밀번호, 새로운 비밀번호에 대한 검증 로직이 추가되었습니다.
- 인증 코드 삭제 로직을 검증 이후로 위치를 변경했습니다.
- Password Reset 요청 DTO를 파라미터로 받도록 코드를 수정했습니다.