### PR TITLE
fix: Event 수정 여부 체크 시 LocalDate.parse() 에러 해결

### DIFF
--- a/src/main/java/com/example/codebase/domain/exhibition/entity/Event.java
+++ b/src/main/java/com/example/codebase/domain/exhibition/entity/Event.java
@@ -242,10 +242,10 @@ public class Event {
         if(!this.link.equals(detailEventData.getUrl())){
             this.link = detailEventData.getUrl();
         }
-        if(!this.startDate.equals(LocalDate.parse(detailEventData.getStartDate()))){
+        if(!this.startDate.equals(LocalDate.parse(detailEventData.getStartDate(), DateTimeFormatter.ofPattern("yyyyMMdd")))){
             this.startDate = LocalDate.parse(detailEventData.getStartDate());
         }
-        if(!this.endDate.equals(LocalDate.parse(detailEventData.getEndDate()))){
+        if(!this.endDate.equals(LocalDate.parse(detailEventData.getEndDate(), DateTimeFormatter.ofPattern("yyyyMMdd")))){
             this.endDate = LocalDate.parse(detailEventData.getEndDate());
         }
         if(!this.location.equals(location)){


### PR DESCRIPTION
- LocalDate로 변환할 문자열 형식을 알려주도록 코드를 수정했습니다.

크롤링 후 다시 요청을 보내면 "20231214" 문자열을 LocalDate.parse() 시 포맷을 지정하지 않아 에러가 발생하는데 이를 해결했습니다.
`java.time.format.DateTimeParseException: Text '20231214' could not be parsed at index 0`
