### PR TITLE
피드에 크롤링된 이벤트 노출하지 않도록 수정

### DIFF
--- a/src/main/java/com/example/codebase/domain/exhibition/repository/EventRepository.java
+++ b/src/main/java/com/example/codebase/domain/exhibition/repository/EventRepository.java
@@ -20,4 +20,6 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 
     @Query("SELECT e FROM Event e WHERE e.seq = :seq")
     Optional<Event> findBySeq(Long seq);
+
+    Page<Event> findAllBySeqIsNull(PageRequest pageRequest);
 }

--- a/src/main/java/com/example/codebase/domain/feed/dto/FeedItemEventResponseDto.java
+++ b/src/main/java/com/example/codebase/domain/feed/dto/FeedItemEventResponseDto.java
@@ -23,10 +23,10 @@ public class FeedItemEventResponseDto {
 
     private String detailLocation;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm")
-    private LocalDateTime startDateTime;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm")
-    private LocalDateTime endDateTime;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
 
 }

--- a/src/main/java/com/example/codebase/domain/feed/dto/FeedItemResponseDto.java
+++ b/src/main/java/com/example/codebase/domain/feed/dto/FeedItemResponseDto.java
@@ -8,6 +8,8 @@ import com.example.codebase.domain.agora.entity.AgoraWithParticipant;
 import com.example.codebase.domain.artwork.entity.Artwork;
 import com.example.codebase.domain.artwork.entity.ArtworkMedia;
 import com.example.codebase.domain.artwork.entity.ArtworkWithIsLike;
+import com.example.codebase.domain.exhibition.entity.Event;
+import com.example.codebase.domain.exhibition.entity.EventMedia;
 import com.example.codebase.domain.exhibition.entity.Exhibition;
 import com.example.codebase.domain.exhibition.entity.ExhibitionMedia;
 import com.example.codebase.domain.post.entity.Post;
@@ -170,6 +172,7 @@ public class FeedItemResponseDto {
         return dto;
     }
 
+    @Deprecated
     public static FeedItemResponseDto from(Exhibition exhibition) {
         FeedItemResponseDto dto =
                 FeedItemResponseDto.builder()
@@ -202,8 +205,8 @@ public class FeedItemResponseDto {
             FeedItemEventResponseDto eventDto =
                     FeedItemEventResponseDto.builder()
                             .eventType(exhibition.getType())
-                            .startDateTime(exhibition.getFirstEventSchedule().getStartDateTime())
-                            .endDateTime(exhibition.getFirstEventSchedule().getEndDateTime())
+                            .startDate(exhibition.getFirstEventSchedule().getStartDateTime().toLocalDate())
+                            .endDate(exhibition.getFirstEventSchedule().getEndDateTime().toLocalDate())
                             .locationName(exhibition.getFirstEventSchedule().getLocation().getName())
                             .locationAddress(exhibition.getFirstEventSchedule().getLocation().getAddress())
                             .detailLocation(exhibition.getFirstEventSchedule().getDetailLocation())
@@ -211,7 +214,7 @@ public class FeedItemResponseDto {
             dto.setEvent(eventDto);
         }
 
-        if (exhibition.getExhibitionMedias().size() > 0) {
+        if (!exhibition.getExhibitionMedias().isEmpty()) {
             String thumbnailUrl = exhibition.getExhibitionMedias().get(0).getMediaUrl();
             List<String> mediaUrls =
                     exhibition.getExhibitionMedias().stream()
@@ -267,7 +270,7 @@ public class FeedItemResponseDto {
                 .updatedTime(agora.getUpdatedTime())
                 .build();
 
-        if (agora.getMedias() != null && agora.getMedias().size() > 0) {
+        if (agora.getMedias() != null && !agora.getMedias().isEmpty()) {
             String thumbnailUrl = agora.getMedias().stream().findFirst().get().getMediaUrl();
             List<String> mediaUrls = agora.getMedias().stream()
                     .map(AgoraMedia::getMediaUrl)
@@ -280,4 +283,56 @@ public class FeedItemResponseDto {
         return dto;
     }
 
+    public static FeedItemResponseDto from(Event event) {
+        FeedItemResponseDto dto =
+                FeedItemResponseDto.builder()
+                        .id(event.getId())
+                        .type(FeedType.event)
+                        .title(event.getTitle())
+                        .content(event.getDescription())
+                        .authorName(event.getMember().getName())
+                        .authorUsername(event.getMember().getUsername())
+                        .authorIntroduction(event.getMember().getIntroduction())
+                        .authorProfileImageUrl(event.getMember().getPicture())
+                        .authorCompanyName(
+                                event.getMember().getCompanyName() != null
+                                        ? event.getMember().getCompanyName()
+                                        : null)
+                        .authorCompanyRole(
+                                event.getMember().getCompanyRole() != null
+                                        ? event.getMember().getCompanyRole()
+                                        : null)
+                        .tags(null)
+                        .categoryId(FeedType.event.name())
+                        .views(0)
+                        .likes(0)
+                        .comments(0)
+                        .createdTime(event.getCreatedTime())
+                        .updatedTime(event.getUpdatedTime())
+                        .build();
+
+        FeedItemEventResponseDto eventDto =
+                FeedItemEventResponseDto.builder()
+                        .eventType(event.getType())
+                        .startDate(event.getStartDate())
+                        .endDate(event.getEndDate())
+                        .locationName(event.getLocation().getName())
+                        .locationAddress(event.getLocation().getAddress())
+                        .detailLocation(event.getDetailLocation())
+                        .build();
+        dto.setEvent(eventDto);
+
+
+        if (!event.getEventMedias().isEmpty()) {
+            String thumbnailUrl = event.getEventMedias().get(0).getMediaUrl();
+            List<String> mediaUrls =
+                    event.getEventMedias().stream()
+                            .map(EventMedia::getMediaUrl)
+                            .toList();
+            dto.setThumbnailUrl(thumbnailUrl);
+            dto.setMediaUrls(mediaUrls);
+        }
+
+        return dto;
+    }
 }

--- a/src/main/java/com/example/codebase/domain/feed/dto/FeedType.java
+++ b/src/main/java/com/example/codebase/domain/feed/dto/FeedType.java
@@ -9,9 +9,9 @@ public enum FeedType {
 
     post,
 
-    exhibition,
+    event,
 
-    agora;
+    agora, exhibition;
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static FeedType create(String type) {

--- a/src/main/java/com/example/codebase/domain/feed/service/FeedService.java
+++ b/src/main/java/com/example/codebase/domain/feed/service/FeedService.java
@@ -7,7 +7,9 @@ import com.example.codebase.domain.artwork.dto.ArtworkResponseDTO;
 import com.example.codebase.domain.artwork.entity.Artwork;
 import com.example.codebase.domain.artwork.entity.ArtworkWithIsLike;
 import com.example.codebase.domain.artwork.repository.ArtworkRepository;
+import com.example.codebase.domain.exhibition.entity.Event;
 import com.example.codebase.domain.exhibition.entity.Exhibition;
+import com.example.codebase.domain.exhibition.repository.EventRepository;
 import com.example.codebase.domain.exhibition.repository.ExhibitionRepository;
 import com.example.codebase.domain.feed.dto.FeedItemResponseDto;
 import com.example.codebase.domain.feed.dto.FeedResponseDto;
@@ -35,15 +37,18 @@ public class FeedService {
     private final ArtworkRepository artworkRepository;
     private final PostRepository postRepository;
     private final ExhibitionRepository exhibitionRepository;
+
+    private final EventRepository eventRepository;
     private final AgoraRepository agoraRepository;
     private final MemberRepository memberRepository;
 
     @Autowired
     public FeedService(ArtworkRepository artworkRepository, PostRepository postRepository,
-                       ExhibitionRepository exhibitionRepository, AgoraRepository agoraRepository, MemberRepository memberRepository) {
+                       ExhibitionRepository exhibitionRepository, EventRepository eventRepository, AgoraRepository agoraRepository, MemberRepository memberRepository) {
         this.artworkRepository = artworkRepository;
         this.postRepository = postRepository;
         this.exhibitionRepository = exhibitionRepository;
+        this.eventRepository = eventRepository;
         this.agoraRepository = agoraRepository;
         this.memberRepository = memberRepository;
     }
@@ -73,9 +78,9 @@ public class FeedService {
         feedItems.addAll(postItems);
 
         // 전시 조회
-        Page<Exhibition> exhibitions = exhibitionRepository.findAll(pageRequest);
+        Page<Event> events = eventRepository.findAllBySeqIsNull(pageRequest);
 
-        List<FeedItemResponseDto> exhibitionItems = exhibitions
+        List<FeedItemResponseDto> exhibitionItems = events
                 .stream()
                 .map(FeedItemResponseDto::from)
                 .toList();
@@ -93,7 +98,7 @@ public class FeedService {
         // application sort
         feedItems.sort((o1, o2) -> o2.getCreatedTime().compareTo(o1.getCreatedTime()));
 
-        boolean hasNext = artworks.hasNext() || posts.hasNext() || exhibitions.hasNext() || agoras.hasNext();
+        boolean hasNext = artworks.hasNext() || posts.hasNext() || events.hasNext() || agoras.hasNext();
         return FeedResponseDto.of(feedItems, hasNext);
     }
 
@@ -125,9 +130,9 @@ public class FeedService {
         feedItems.addAll(postItems);
 
         // 전시 조회
-        Page<Exhibition> exhibitions = exhibitionRepository.findAll(pageRequest);
+        Page<Event> events = eventRepository.findAllBySeqIsNull(pageRequest);
 
-        List<FeedItemResponseDto> exhibitionItems = exhibitions
+        List<FeedItemResponseDto> exhibitionItems = events
                 .stream()
                 .map(FeedItemResponseDto::from)
                 .toList();
@@ -144,7 +149,7 @@ public class FeedService {
         // application sort
         feedItems.sort((o1, o2) -> o2.getCreatedTime().compareTo(o1.getCreatedTime()));
 
-        boolean hasNext = artworks.hasNext() || posts.hasNext() || exhibitions.hasNext() || agoras.hasNext();
+        boolean hasNext = artworks.hasNext() || posts.hasNext() || events.hasNext() || agoras.hasNext();
         return FeedResponseDto.of(feedItems, hasNext);
     }
 

--- a/src/main/java/com/example/codebase/domain/feed/service/FeedService.java
+++ b/src/main/java/com/example/codebase/domain/feed/service/FeedService.java
@@ -36,18 +36,14 @@ public class FeedService {
 
     private final ArtworkRepository artworkRepository;
     private final PostRepository postRepository;
-    private final ExhibitionRepository exhibitionRepository;
-
     private final EventRepository eventRepository;
     private final AgoraRepository agoraRepository;
     private final MemberRepository memberRepository;
 
     @Autowired
-    public FeedService(ArtworkRepository artworkRepository, PostRepository postRepository,
-                       ExhibitionRepository exhibitionRepository, EventRepository eventRepository, AgoraRepository agoraRepository, MemberRepository memberRepository) {
+    public FeedService(ArtworkRepository artworkRepository, PostRepository postRepository, EventRepository eventRepository, AgoraRepository agoraRepository, MemberRepository memberRepository) {
         this.artworkRepository = artworkRepository;
         this.postRepository = postRepository;
-        this.exhibitionRepository = exhibitionRepository;
         this.eventRepository = eventRepository;
         this.agoraRepository = agoraRepository;
         this.memberRepository = memberRepository;


### PR DESCRIPTION
- 피드 생성 시 이벤트 데이터를 조회하는 쿼리를 크롤링 한 이벤트는 가져오지 않도록 수정했습니다.
- 피드 생성 시 Exhibition 이 Deprecated 됨에 따라 관련 로직을 Event 객체로 사용하도록 변경했습니다.
- Exhibition과 호환할 수 있도록 기존 코드를 수정했습니다.
- Exhibition 관련 피드 로직에 @Deprecated 이 부착되었습니다.