### PR TITLE
fix: 이벤트 전체 조회, 상세조회 dto 문제 해결

### DIFF
--- a/src/main/java/com/example/codebase/domain/exhibition/dto/EventDetailResponseDTO.java
+++ b/src/main/java/com/example/codebase/domain/exhibition/dto/EventDetailResponseDTO.java
@@ -65,7 +65,7 @@ public class EventDetailResponseDTO {
                 medias.stream().findFirst().map(ExhibitionMediaResponseDTO::from).orElse(null);
 
         List<ExhibitionMediaResponseDTO> exhibitionMediaResponseDTOS =
-                medias.stream().skip(1).map(ExhibitionMediaResponseDTO::from).collect(Collectors.toList());
+                medias.stream().map(ExhibitionMediaResponseDTO::from).collect(Collectors.toList());
 
         LocationResponseDTO locationResponseDTO = LocationResponseDTO.from(event.getLocation());
 

--- a/src/main/java/com/example/codebase/domain/exhibition/dto/EventResponseDTO.java
+++ b/src/main/java/com/example/codebase/domain/exhibition/dto/EventResponseDTO.java
@@ -21,8 +21,6 @@ public class EventResponseDTO {
 
     private String author;
 
-    private ExhibitionPageInfoResponseDTO exhibition;
-
     private ExhibitionMediaResponseDTO thumbnail;
 
     private EventType eventType;


### PR DESCRIPTION
- event를 전체 조회할때 exhibition이 반환되던 문제를 해결했습니다.
- 이제 event를 상세조회할때 thumbnail도 media에 포함됩니다.