### PR TITLE
Fix/elasticsearch integration test fail

### DIFF
--- a/src/main/java/com/example/codebase/controller/SearchController.java
+++ b/src/main/java/com/example/codebase/controller/SearchController.java
@@ -47,7 +47,7 @@ public class SearchController {
             @RequestParam(defaultValue = "정확도순", required = false) String sortType
     ) {
         if (API_DISABLE) {
-            return new ResponseEntity("API 제공이 임시 중지 되었습니다",HttpStatus.OK);
+            return new ResponseEntity(new SearchResponseDTO(),HttpStatus.OK);
         }
         PageRequest pageRequest = PageRequestMaker.makePageRequest(page, size, sortType);
 
@@ -69,7 +69,7 @@ public class SearchController {
             @RequestParam(defaultValue = "정확도순", required = false) String sortType
     ) {
         if (API_DISABLE) {
-            return new ResponseEntity("API 제공이 임시 중지 되었습니다",HttpStatus.OK);
+            return new ResponseEntity(new ArtworksResponseDTO(),HttpStatus.OK);
         }
 
         PageRequest pageRequest = PageRequestMaker.makePageRequest(page, size, sortType);
@@ -93,7 +93,7 @@ public class SearchController {
             @RequestParam(defaultValue = "정확도순", required = false) String sortType
     ) {
         if (API_DISABLE) {
-            return new ResponseEntity("API 제공이 임시 중지 되었습니다",HttpStatus.OK);
+            return new ResponseEntity(new PostsResponseDTO(),HttpStatus.OK);
         }
 
         PageRequest pageRequest = PageRequestMaker.makePageRequest(page, size, sortType);
@@ -117,7 +117,7 @@ public class SearchController {
             @RequestParam(defaultValue = "정확도순", required = false) String sortType
     ) {
         if (API_DISABLE) {
-            return new ResponseEntity("API 제공이 임시 중지 되었습니다",HttpStatus.OK);
+            return new ResponseEntity(new AgorasResponseDTO(),HttpStatus.OK);
         }
 
         PageRequest pageRequest = PageRequestMaker.makePageRequest(page, size, sortType);
@@ -141,7 +141,7 @@ public class SearchController {
             @RequestParam(defaultValue = "정확도순", required = false) String sortType
     ) {
         if (API_DISABLE) {
-            return new ResponseEntity("API 제공이 임시 중지 되었습니다",HttpStatus.OK);
+            return new ResponseEntity(new EventsResponseDTO(),HttpStatus.OK);
         }
 
         PageRequest pageRequest = PageRequestMaker.makePageRequest(page, size, sortType);

--- a/src/main/java/com/example/codebase/controller/SearchController.java
+++ b/src/main/java/com/example/codebase/controller/SearchController.java
@@ -27,6 +27,8 @@ public class SearchController {
 
     private final SearchService searchService;
 
+    private static final boolean API_DISABLE = true;
+
     public SearchController(SearchService searchService) {
         this.searchService = searchService;
     }
@@ -44,6 +46,9 @@ public class SearchController {
             @PositiveOrZero @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "정확도순", required = false) String sortType
     ) {
+        if (API_DISABLE) {
+            return new ResponseEntity("API 제공이 임시 중지 되었습니다",HttpStatus.OK);
+        }
         PageRequest pageRequest = PageRequestMaker.makePageRequest(page, size, sortType);
 
         SearchResponseDTO dto = searchService.searchTotal(keyword, pageRequest);
@@ -63,6 +68,10 @@ public class SearchController {
             @PositiveOrZero @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "정확도순", required = false) String sortType
     ) {
+        if (API_DISABLE) {
+            return new ResponseEntity("API 제공이 임시 중지 되었습니다",HttpStatus.OK);
+        }
+
         PageRequest pageRequest = PageRequestMaker.makePageRequest(page, size, sortType);
 
         ArtworksResponseDTO dto = searchService.searchArtwork(keyword, pageRequest);
@@ -83,6 +92,10 @@ public class SearchController {
             @PositiveOrZero @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "정확도순", required = false) String sortType
     ) {
+        if (API_DISABLE) {
+            return new ResponseEntity("API 제공이 임시 중지 되었습니다",HttpStatus.OK);
+        }
+
         PageRequest pageRequest = PageRequestMaker.makePageRequest(page, size, sortType);
 
         PostsResponseDTO dto = searchService.searchPost(keyword, pageRequest);
@@ -103,6 +116,10 @@ public class SearchController {
             @PositiveOrZero @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "정확도순", required = false) String sortType
     ) {
+        if (API_DISABLE) {
+            return new ResponseEntity("API 제공이 임시 중지 되었습니다",HttpStatus.OK);
+        }
+
         PageRequest pageRequest = PageRequestMaker.makePageRequest(page, size, sortType);
 
         AgorasResponseDTO dto = searchService.searchAgora(keyword, pageRequest);
@@ -123,6 +140,10 @@ public class SearchController {
             @PositiveOrZero @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "정확도순", required = false) String sortType
     ) {
+        if (API_DISABLE) {
+            return new ResponseEntity("API 제공이 임시 중지 되었습니다",HttpStatus.OK);
+        }
+
         PageRequest pageRequest = PageRequestMaker.makePageRequest(page, size, sortType);
 
         EventsResponseDTO dto = searchService.searchEvent(keyword, pageRequest);

--- a/src/main/java/com/example/codebase/domain/Event/repository/EventDocumentRepository.java
+++ b/src/main/java/com/example/codebase/domain/Event/repository/EventDocumentRepository.java
@@ -3,5 +3,5 @@ package com.example.codebase.domain.Event.repository;
 import com.example.codebase.domain.Event.document.EventDocument;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
-public interface EventDocumentRepository extends ElasticsearchRepository<EventDocument, Long> {
+public interface EventDocumentRepository {
 }

--- a/src/main/java/com/example/codebase/domain/agora/repository/AgoraDocumentRepository.java
+++ b/src/main/java/com/example/codebase/domain/agora/repository/AgoraDocumentRepository.java
@@ -3,5 +3,5 @@ package com.example.codebase.domain.agora.repository;
 import com.example.codebase.domain.agora.document.AgoraDocument;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
-public interface AgoraDocumentRepository extends ElasticsearchRepository<AgoraDocument, Long> {
+public interface AgoraDocumentRepository {
 }

--- a/src/main/java/com/example/codebase/domain/agora/service/AgoraService.java
+++ b/src/main/java/com/example/codebase/domain/agora/service/AgoraService.java
@@ -27,17 +27,15 @@ public class AgoraService {
     private final AgoraParticipantRepository agoraParticipantRepository;
     private final AgoraMediaRepository agoraMediaRepository;
     private final AgoraOpinionRepository agoraOpinionRepository;
-    private final AgoraDocumentRepository agoraDocumentRepository;
     private final S3Service s3Service;
 
     @Autowired
-    public AgoraService(MemberRepository memberRepository, AgoraRepository agoraRepository, AgoraParticipantRepository agoraParticipantRepository, AgoraMediaRepository agoraMediaRepository, AgoraOpinionRepository agoraOpinionRepository, AgoraDocumentRepository agoraDocumentRepository, S3Service s3Service) {
+    public AgoraService(MemberRepository memberRepository, AgoraRepository agoraRepository, AgoraParticipantRepository agoraParticipantRepository, AgoraMediaRepository agoraMediaRepository, AgoraOpinionRepository agoraOpinionRepository, S3Service s3Service) {
         this.memberRepository = memberRepository;
         this.agoraRepository = agoraRepository;
         this.agoraParticipantRepository = agoraParticipantRepository;
         this.agoraMediaRepository = agoraMediaRepository;
         this.agoraOpinionRepository = agoraOpinionRepository;
-        this.agoraDocumentRepository = agoraDocumentRepository;
         this.s3Service = s3Service;
     }
 
@@ -142,7 +140,7 @@ public class AgoraService {
 
         agora.delete();
         agoraRepository.save(agora);
-        agoraDocumentRepository.deleteById(agoraId);
+//        agoraDocumentRepository.deleteById(agoraId); // TODO : ElasticSearch 의존 관계 제거
     }
 
 

--- a/src/main/java/com/example/codebase/domain/artwork/repository/ArtworkDocumentRepository.java
+++ b/src/main/java/com/example/codebase/domain/artwork/repository/ArtworkDocumentRepository.java
@@ -3,5 +3,5 @@ package com.example.codebase.domain.artwork.repository;
 import com.example.codebase.domain.artwork.document.ArtworkDocument;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
-public interface ArtworkDocumentRepository extends ElasticsearchRepository<ArtworkDocument, Long> {
+public interface ArtworkDocumentRepository {
 }

--- a/src/main/java/com/example/codebase/domain/artwork/service/ArtworkService.java
+++ b/src/main/java/com/example/codebase/domain/artwork/service/ArtworkService.java
@@ -31,18 +31,17 @@ public class ArtworkService {
     private final ArtworkRepository artworkRepository;
     private final ArtworkCommentRepository artworkCommentRepository;
     private final ArtworkLikeMemberRepository artworkLikeMemberRepository;
-    private final ArtworkDocumentRepository artworkDocumentRepository;
+//    private final ArtworkDocumentRepository artworkDocumentRepository;
     private final S3Service s3Service;
     private final MemberRepository memberRepository;
 
     @Autowired
     public ArtworkService(ArtworkRepository artworkRepository, ArtworkCommentRepository artworkCommentRepository,
-                          ArtworkLikeMemberRepository artworkLikeMemberRepository, ArtworkDocumentRepository artworkDocumentRepository, S3Service s3Service,
+                          ArtworkLikeMemberRepository artworkLikeMemberRepository, S3Service s3Service,
                           MemberRepository memberRepository) {
         this.artworkRepository = artworkRepository;
         this.artworkCommentRepository = artworkCommentRepository;
         this.artworkLikeMemberRepository = artworkLikeMemberRepository;
-        this.artworkDocumentRepository = artworkDocumentRepository;
         this.s3Service = s3Service;
         this.memberRepository = memberRepository;
     }
@@ -156,7 +155,7 @@ public class ArtworkService {
         s3Service.deleteArtworkMediaS3Objects(artworkMedias);
 
         artworkRepository.delete(artwork);
-        artworkDocumentRepository.deleteById(id);
+//        artworkDocumentRepository.deleteById(id); // TODO : ElasticSearch 의존 관계 제거
     }
 
     public ArtworkResponseDTO updateArtworkMedia(Long id, Long mediaId, ArtworkMediaCreateDTO dto, String username) {

--- a/src/main/java/com/example/codebase/domain/post/repository/PostDocumentRepository.java
+++ b/src/main/java/com/example/codebase/domain/post/repository/PostDocumentRepository.java
@@ -3,5 +3,5 @@ package com.example.codebase.domain.post.repository;
 import com.example.codebase.domain.post.document.PostDocument;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
-public interface PostDocumentRepository extends ElasticsearchRepository<PostDocument, Long> {
+public interface PostDocumentRepository {
 }

--- a/src/main/java/com/example/codebase/domain/post/service/PostService.java
+++ b/src/main/java/com/example/codebase/domain/post/service/PostService.java
@@ -29,7 +29,8 @@ public class PostService {
     private final MemberRepository memberRepository;
     private final PostLikeMemberRepository postLikeMemberRepository;
     private final PostCommentRepository postCommentRepository;
-    private final PostDocumentRepository postDocumentRepository;
+
+//    private final PostDocumentRepository postDocumentRepository;
     private final S3Service s3Service;
 
     @Autowired
@@ -37,12 +38,12 @@ public class PostService {
             PostRepository postRepository,
             MemberRepository memberRepository,
             PostLikeMemberRepository postLikeMemberRepository,
-            PostCommentRepository postCommentRepository, PostDocumentRepository postDocumentRepository, S3Service s3Service) {
+            PostCommentRepository postCommentRepository,
+            S3Service s3Service) {
         this.postRepository = postRepository;
         this.memberRepository = memberRepository;
         this.postLikeMemberRepository = postLikeMemberRepository;
         this.postCommentRepository = postCommentRepository;
-        this.postDocumentRepository = postDocumentRepository;
         this.s3Service = s3Service;
     }
 
@@ -129,7 +130,7 @@ public class PostService {
 
 
         postRepository.delete(post);
-        postDocumentRepository.deleteById(postId);
+//        postDocumentRepository.deleteById(postId); // TODO : ElasticSearch 의존 메서드 제거할 수 있는 방법 찾기 (// TODO : ElasticSearch 의존 관계 제거)
     }
 
     public PostWithLikesResponseDTO getPost(Long postId) {

--- a/src/main/resources/application-es.yaml
+++ b/src/main/resources/application-es.yaml
@@ -1,4 +1,11 @@
 
+---
+spring:
+  config:
+    activate:
+      on-profile:
+        - dev
+
 elasticsearch:
   host: ENC(h2zwdrTTT3YDNlIIZd+EHLf+TZn7iotT1h6LNTkft01UP28M2E+hJ+0WNGVjQmkI)
   username: ENC(gOeYrnq0KVLNP77ppWKArcqDQwcR8goFCcdEqSha1rk=)

--- a/src/test/java/com/example/codebase/config/ElasticSearchConfig.java
+++ b/src/test/java/com/example/codebase/config/ElasticSearchConfig.java
@@ -1,0 +1,8 @@
+package com.example.codebase.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+
+@TestConfiguration
+public class ElasticSearchConfig {
+
+}

--- a/src/test/java/com/example/codebase/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/AuthControllerTest.java
@@ -60,7 +60,7 @@ class AuthControllerTest {
     private PasswordEncoder passwordEncoder;
 
     @Autowired
-    private RedisUtil redisUtil;
+    private RedisUtil redisUtil; // TODO: Redis Mocking 이 필요함
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 


### PR DESCRIPTION
- ElasticSearch 외부 연결이 끊어졌을 시 테스트 및 빌드가 실패하는 이슈를 해결했습니다.
- ElasticSearch DocumentRepository Jpa 관련 상속을 제거하였습니다.
  - 이로 인해 DocumentRepository는 Spring 컨테이너가 관리하지 않습니다
- 테스트 시 ElasticSearchConfig를 TestConfiguration 용으로 재정의하여 연결을 시도하지 않도록 클래스를 작성했습니다.