### PR TITLE
매거진 기능 구현

### DIFF
--- a/src/main/java/com/example/codebase/annotation/AdminOnly.java
+++ b/src/main/java/com/example/codebase/annotation/AdminOnly.java
@@ -1,0 +1,13 @@
+package com.example.codebase.annotation;
+
+import jakarta.persistence.Table;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_ADMIN')")
+public @interface AdminOnly {
+
+}

--- a/src/main/java/com/example/codebase/annotation/LoginOnly.java
+++ b/src/main/java/com/example/codebase/annotation/LoginOnly.java
@@ -1,0 +1,14 @@
+package com.example.codebase.annotation;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("isAuthenticated()")
+public @interface LoginOnly {
+}

--- a/src/main/java/com/example/codebase/annotation/UserAdminOnly.java
+++ b/src/main/java/com/example/codebase/annotation/UserAdminOnly.java
@@ -1,0 +1,14 @@
+package com.example.codebase.annotation;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")
+public @interface UserAdminOnly {
+}

--- a/src/main/java/com/example/codebase/annotation/UserOnly.java
+++ b/src/main/java/com/example/codebase/annotation/UserOnly.java
@@ -1,0 +1,14 @@
+package com.example.codebase.annotation;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER')")
+public @interface UserOnly {
+}

--- a/src/main/java/com/example/codebase/controller/MagazineCategoryController.java
+++ b/src/main/java/com/example/codebase/controller/MagazineCategoryController.java
@@ -24,8 +24,8 @@ public class MagazineCategoryController {
     @PostMapping
     @AdminOnly
     public ResponseEntity createCategory(String name) {
-        magazineCategoryService.createCategory(name);
-        return new ResponseEntity(name + " 생성 완료", HttpStatus.CREATED);
+        MagazineCategoryResponse.Get category = magazineCategoryService.createCategory(name);
+        return new ResponseEntity(category, HttpStatus.CREATED);
     }
 
     @GetMapping

--- a/src/main/java/com/example/codebase/controller/MagazineCategoryController.java
+++ b/src/main/java/com/example/codebase/controller/MagazineCategoryController.java
@@ -25,7 +25,7 @@ public class MagazineCategoryController {
     @AdminOnly
     public ResponseEntity createCategory(String name) {
         magazineCategoryService.createCategory(name);
-        return new ResponseEntity(name + " 생성 완료", HttpStatus.OK);
+        return new ResponseEntity(name + " 생성 완료", HttpStatus.CREATED);
     }
 
     @GetMapping

--- a/src/main/java/com/example/codebase/controller/MagazineCategoryController.java
+++ b/src/main/java/com/example/codebase/controller/MagazineCategoryController.java
@@ -1,0 +1,37 @@
+package com.example.codebase.controller;
+
+
+import com.example.codebase.annotation.AdminOnly;
+import com.example.codebase.domain.magazine.dto.MagazineCategoryResponse;
+import com.example.codebase.domain.magazine.service.MagazineCategoryService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/magazine-category")
+public class MagazineCategoryController {
+
+    private final MagazineCategoryService magazineCategoryService;
+
+    public MagazineCategoryController(MagazineCategoryService magazineCategoryService) {
+        this.magazineCategoryService = magazineCategoryService;
+    }
+
+    @PostMapping
+    @AdminOnly
+    public ResponseEntity createCategory(String name) {
+        magazineCategoryService.createCategory(name);
+        return new ResponseEntity(name + " 생성 완료", HttpStatus.OK);
+    }
+
+    @GetMapping
+    public ResponseEntity getCategories() {
+        MagazineCategoryResponse.GetAll allCategory = magazineCategoryService.getAllCategory();
+        return new ResponseEntity(allCategory, HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/com/example/codebase/controller/MagazineController.java
+++ b/src/main/java/com/example/codebase/controller/MagazineController.java
@@ -1,0 +1,99 @@
+package com.example.codebase.controller;
+
+import com.example.codebase.annotation.UserOnly;
+import com.example.codebase.domain.magazine.dto.MagazineRequest;
+import com.example.codebase.domain.magazine.dto.MagazineResponse;
+import com.example.codebase.domain.magazine.entity.MagazineCategory;
+import com.example.codebase.domain.magazine.service.MagazineCategoryService;
+import com.example.codebase.domain.magazine.service.MagazineService;
+import com.example.codebase.domain.member.entity.Member;
+import com.example.codebase.domain.member.service.MemberService;
+import com.example.codebase.exception.LoginRequiredException;
+import com.example.codebase.util.SecurityUtil;
+import jakarta.validation.constraints.PositiveOrZero;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+@RestController
+@RequestMapping("/api/magazines")
+public class MagazineController {
+
+    private final MagazineService magazineService;
+
+    private final MagazineCategoryService magazineCategoryService;
+
+    private final MemberService memberService;
+
+    @Autowired
+    public MagazineController(MagazineService magazineService, MagazineCategoryService magazineCategoryService, MemberService memberService) {
+        this.magazineService = magazineService;
+        this.magazineCategoryService = magazineCategoryService;
+        this.memberService = memberService;
+    }
+
+    @PostMapping
+    @UserOnly
+    public ResponseEntity createMagazine(
+            @RequestBody MagazineRequest.Create magazineRequest
+    ) {
+        String loginUsername = SecurityUtil.getCurrentUsername().orElseThrow(LoginRequiredException::new);
+
+        // 연관 객체 조회
+        Member member = memberService.getEntity(loginUsername);
+        MagazineCategory category = magazineCategoryService.getEntity(magazineRequest.getCategoryId());
+
+        // 매거진 생성 로직 수행
+        MagazineResponse.Get magazine = magazineService.create(magazineRequest, member, category);
+
+        return new ResponseEntity(magazine, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity getMagazine(
+            @PathVariable Long id
+    ) {
+        MagazineResponse.Get magazine = magazineService.get(id);
+
+        return new ResponseEntity(magazine, HttpStatus.OK);
+    }
+
+    @GetMapping
+    public ResponseEntity getMagazines(
+            @PositiveOrZero @RequestParam(value = "page", defaultValue = "0") int page,
+            @PositiveOrZero @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam(defaultValue = "DESC", required = false) String sortDirection
+    ) {
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by(Sort.Direction.fromString(sortDirection), "createdTime"));
+        MagazineResponse.GetAll allMagazines = magazineService.getAll(pageRequest);
+
+        return new ResponseEntity(allMagazines, HttpStatus.OK);
+    }
+
+    @PutMapping("/{id}")
+    @UserOnly
+    public ResponseEntity updateMagazine(
+            @PathVariable Long id,
+            @RequestBody MagazineRequest.Update magazineRequest
+    ) {
+        String loginUsername = SecurityUtil.getCurrentUsername()
+                .orElseThrow(LoginRequiredException::new);
+        MagazineResponse.Get magazine = magazineService.update(id, loginUsername, magazineRequest);
+
+        return new ResponseEntity(magazine, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    @UserOnly
+    public ResponseEntity deleteMagazine(
+            @PathVariable Long id
+    ) {
+        String loginUsername = SecurityUtil.getCurrentUsername()
+                        .orElseThrow(LoginRequiredException::new);
+        magazineService.delete(loginUsername, id);
+
+        return new ResponseEntity("삭제 완료", HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/example/codebase/controller/advice/CustomExceptionHandler.java
+++ b/src/main/java/com/example/codebase/controller/advice/CustomExceptionHandler.java
@@ -4,6 +4,7 @@ import com.example.codebase.controller.dto.RestResponse;
 import com.example.codebase.exception.ErrorCode;
 import com.example.codebase.exception.NotAcceptTypeException;
 import com.example.codebase.exception.NotAccessException;
+import com.example.codebase.exception.NotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -65,6 +66,12 @@ public class CustomExceptionHandler {
         log.info(printStackTrage(e));
         RestResponse response = new RestResponse(false, e.getMessage(), HttpStatus.BAD_REQUEST.value());
         return new ResponseEntity(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity handleNotFoundException(NotFoundException e) {
+        RestResponse response = new RestResponse(false, e.getMessage(), HttpStatus.NOT_FOUND.value());
+        return new ResponseEntity(response, HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(AccessDeniedException.class)

--- a/src/main/java/com/example/codebase/domain/magazine/dto/AuthorResponse.java
+++ b/src/main/java/com/example/codebase/domain/magazine/dto/AuthorResponse.java
@@ -1,0 +1,35 @@
+package com.example.codebase.domain.magazine.dto;
+
+import com.example.codebase.domain.member.entity.Member;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AuthorResponse {
+
+    private String authorUsername;
+
+    private String authorName;
+
+    private String authorProfileImage;
+
+    private String authorIntroduction;
+
+    private String authorCompanyName;
+
+    private String authorCompanyRole;
+
+    public static AuthorResponse from(Member member) {
+
+        AuthorResponse response = new AuthorResponse();
+        response.authorUsername = member.getUsername();
+        response.authorName = member.getName();
+        response.authorProfileImage = member.getPicture();
+        response.authorIntroduction = member.getIntroduction();
+        response.authorCompanyName = member.getCompanyName();
+        response.authorCompanyRole = member.getCompanyRole();
+
+        return response;
+    }
+}

--- a/src/main/java/com/example/codebase/domain/magazine/dto/MagazineCategoryRequest.java
+++ b/src/main/java/com/example/codebase/domain/magazine/dto/MagazineCategoryRequest.java
@@ -1,0 +1,18 @@
+package com.example.codebase.domain.magazine.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+public class MagazineCategoryRequest {
+
+    @Getter
+    @Setter
+    @Schema(name = "MagazineCategoryRequest", description = "카테고리 생성 요청")
+    public static class Create {
+
+        @Schema(description = "카테고리 이름", example = "Post")
+        private String name;
+    }
+
+}

--- a/src/main/java/com/example/codebase/domain/magazine/dto/MagazineCategoryResponse.java
+++ b/src/main/java/com/example/codebase/domain/magazine/dto/MagazineCategoryResponse.java
@@ -1,0 +1,57 @@
+package com.example.codebase.domain.magazine.dto;
+
+import com.example.codebase.domain.magazine.entity.MagazineCategory;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class MagazineCategoryResponse {
+
+    @Getter
+    @Setter
+    @Schema(name = "MagazineCategoryResponse", description = "Category Response")
+    public static class Get {
+
+        private Long id;
+
+        private String name;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        private LocalDateTime createdTime;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        private LocalDateTime updatedTime;
+
+        public static MagazineCategoryResponse.Get from(MagazineCategory category) {
+            Get get = new Get();
+            get.setId(category.getId());
+            get.setName(category.getName());
+            get.setCreatedTime(category.getCreatedTime());
+            get.setUpdatedTime(category.getUpdatedTime());
+            return get;
+        }
+    }
+
+    @Getter
+    @Setter
+    @Schema(name = "MagazineCategoryRequest", description = "MagazineCategoryRequest")
+    public static class GetAll {
+
+        private List<Get> categories;
+
+
+        public static GetAll from(List<MagazineCategory> all) {
+            GetAll getAll = new GetAll();
+            getAll.setCategories(all.stream()
+                    .map(Get::from)
+                    .toList());
+            return getAll;
+        }
+    }
+
+}

--- a/src/main/java/com/example/codebase/domain/magazine/dto/MagazineCategoryResponse.java
+++ b/src/main/java/com/example/codebase/domain/magazine/dto/MagazineCategoryResponse.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
-import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/com/example/codebase/domain/magazine/dto/MagazineRequest.java
+++ b/src/main/java/com/example/codebase/domain/magazine/dto/MagazineRequest.java
@@ -1,0 +1,33 @@
+package com.example.codebase.domain.magazine.dto;
+
+import com.example.codebase.domain.magazine.entity.Magazine;
+import com.example.codebase.domain.magazine.entity.MagazineCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+public class MagazineRequest {
+
+    @Getter
+    @Setter
+    @Schema(name = "MagazineRequest.Create", description = "매거진 생성 DTO")
+    public static class Create {
+
+        private String title;
+
+        private String content;
+
+        private Long categoryId;
+    }
+
+    @Getter
+    @Setter
+    @Schema(name = "MagazineRequest.Update", description = "매거진 수정 DTO")
+    public static class Update {
+
+        private String title;
+
+        private String content;
+
+    }
+}

--- a/src/main/java/com/example/codebase/domain/magazine/dto/MagazineResponse.java
+++ b/src/main/java/com/example/codebase/domain/magazine/dto/MagazineResponse.java
@@ -1,0 +1,75 @@
+package com.example.codebase.domain.magazine.dto;
+
+import com.example.codebase.controller.dto.PageInfo;
+import com.example.codebase.domain.magazine.entity.Magazine;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.domain.Page;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class MagazineResponse {
+
+    @Getter
+    @Setter
+    @Schema(description = "매거진 생성 응답")
+    public static class Get {
+        private Long id;
+
+        private String title;
+
+        private String content;
+
+        private String category;
+
+        private Integer views;
+
+        private Integer likes;
+
+        private Integer comments;
+
+        private AuthorResponse author;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        private LocalDateTime createdTime;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        private LocalDateTime updatedTime;
+
+        public static Get from(Magazine magazine) {
+            Get response = new Get();
+            response.id = magazine.getId();
+            response.title = magazine.getTitle();
+            response.content = magazine.getContent();
+            response.category = magazine.getCategory().getName();
+            response.views = magazine.getViews();
+            response.likes = magazine.getLikes();
+            response.comments = magazine.getComments();
+            response.author = AuthorResponse.from(magazine.getMember());
+            response.createdTime = magazine.getCreatedTime();
+            response.updatedTime = magazine.getUpdatedTime();
+            return response;
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class GetAll {
+        private List<Get> magazines;
+
+        private PageInfo pageInfo;
+
+        public static GetAll from(Page<Magazine> magazines) {
+            GetAll response = new GetAll();
+
+            response.magazines = magazines.stream()
+                    .map(Get::from)
+                    .toList();
+            response.pageInfo = PageInfo.from(magazines);
+            return response;
+        }
+    }
+}

--- a/src/main/java/com/example/codebase/domain/magazine/entity/Magazine.java
+++ b/src/main/java/com/example/codebase/domain/magazine/entity/Magazine.java
@@ -1,5 +1,6 @@
 package com.example.codebase.domain.magazine.entity;
 
+import com.example.codebase.domain.magazine.dto.MagazineRequest;
 import com.example.codebase.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -58,5 +59,24 @@ public class Magazine {
     @JoinColumn(name = "category_id")
     private MagazineCategory category;
 
+    public static Magazine toEntity(MagazineRequest.Create magazineRequest, Member member, MagazineCategory category) {
+        return Magazine.builder()
+                .title(magazineRequest.getTitle())
+                .content(magazineRequest.getContent())
+                .member(member)
+                .category(category)
+                .createdTime(LocalDateTime.now())
+                .updatedTime(LocalDateTime.now())
+                .build();
+    }
 
+    public boolean isOwner(String loginUsername) {
+        return member.getUsername().equals(loginUsername);
+    }
+
+    public void update(MagazineRequest.Update magazineRequest) {
+        this.title = magazineRequest.getTitle();
+        this.content = magazineRequest.getContent();
+        this.updatedTime = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/example/codebase/domain/magazine/entity/Magazine.java
+++ b/src/main/java/com/example/codebase/domain/magazine/entity/Magazine.java
@@ -1,0 +1,62 @@
+package com.example.codebase.domain.magazine.entity;
+
+import com.example.codebase.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "magazine")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Where(clause = "is_deleted = false")
+public class Magazine {
+
+    @Id
+    @Column(name = "magazine_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "content", columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Builder.Default
+    @Column(name = "views", columnDefinition = "integer default 0")
+    private Integer views = 0;
+
+    @Builder.Default
+    @Column(name = "likes", columnDefinition = "integer default 0")
+    private Integer likes = 0;
+
+    @Builder.Default
+    @Column(name = "comments", columnDefinition = "integer default 0")
+    private Integer comments = 0;
+
+    @Builder.Default
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false;
+
+    private LocalDateTime createdTime;
+
+    private LocalDateTime updatedTime;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", columnDefinition = "BINARY(16)")
+    private Member member;
+
+    @OneToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "category_id")
+    private MagazineCategory category;
+
+
+}

--- a/src/main/java/com/example/codebase/domain/magazine/entity/MagazineCategory.java
+++ b/src/main/java/com/example/codebase/domain/magazine/entity/MagazineCategory.java
@@ -1,0 +1,44 @@
+package com.example.codebase.domain.magazine.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "magazine_category")
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Where(clause = "is_deleted = false")
+public class MagazineCategory {
+
+    @Id
+    @Column(name = "category_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Builder.Default
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false;
+
+    @Builder.Default
+    private LocalDateTime createdTime = LocalDateTime.now();
+
+    @Builder.Default
+    private LocalDateTime updatedTime = LocalDateTime.now();
+
+    public static MagazineCategory toEntity(String name) {
+        return MagazineCategory.builder()
+                .name(name)
+                .build();
+    }
+}

--- a/src/main/java/com/example/codebase/domain/magazine/repository/MagazineCategoryRepository.java
+++ b/src/main/java/com/example/codebase/domain/magazine/repository/MagazineCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.example.codebase.domain.magazine.repository;
+
+import com.example.codebase.domain.magazine.entity.MagazineCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MagazineCategoryRepository extends JpaRepository<MagazineCategory, Long> {
+}

--- a/src/main/java/com/example/codebase/domain/magazine/repository/MagazineRepository.java
+++ b/src/main/java/com/example/codebase/domain/magazine/repository/MagazineRepository.java
@@ -1,0 +1,7 @@
+package com.example.codebase.domain.magazine.repository;
+
+import com.example.codebase.domain.magazine.entity.Magazine;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MagazineRepository extends JpaRepository<Magazine, Long> {
+}

--- a/src/main/java/com/example/codebase/domain/magazine/service/MagazineCategoryService.java
+++ b/src/main/java/com/example/codebase/domain/magazine/service/MagazineCategoryService.java
@@ -3,6 +3,7 @@ package com.example.codebase.domain.magazine.service;
 import com.example.codebase.domain.magazine.dto.MagazineCategoryResponse;
 import com.example.codebase.domain.magazine.entity.MagazineCategory;
 import com.example.codebase.domain.magazine.repository.MagazineCategoryRepository;
+import com.example.codebase.exception.NotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -16,9 +17,10 @@ public class MagazineCategoryService {
         this.magazineCategoryRepository = magazineCategoryRepository;
     }
 
-    public void createCategory(String name) {
+    public MagazineCategoryResponse.Get createCategory(String name) {
         MagazineCategory category = MagazineCategory.toEntity(name);
         magazineCategoryRepository.save(category);
+        return MagazineCategoryResponse.Get.from(category);
     }
 
     public MagazineCategoryResponse.GetAll getAllCategory() {
@@ -28,6 +30,6 @@ public class MagazineCategoryService {
 
     public MagazineCategory getEntity(Long categoryId) {
         return magazineCategoryRepository.findById(categoryId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 카테고리가 존재하지 않습니다."));
+                .orElseThrow(() -> new NotFoundException("해당 카테고리가 존재하지 않습니다."));
     }
 }

--- a/src/main/java/com/example/codebase/domain/magazine/service/MagazineCategoryService.java
+++ b/src/main/java/com/example/codebase/domain/magazine/service/MagazineCategoryService.java
@@ -1,0 +1,28 @@
+package com.example.codebase.domain.magazine.service;
+
+import com.example.codebase.domain.magazine.dto.MagazineCategoryResponse;
+import com.example.codebase.domain.magazine.entity.MagazineCategory;
+import com.example.codebase.domain.magazine.repository.MagazineCategoryRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class MagazineCategoryService {
+
+    private final MagazineCategoryRepository magazineCategoryRepository;
+
+    public MagazineCategoryService(MagazineCategoryRepository magazineCategoryRepository) {
+        this.magazineCategoryRepository = magazineCategoryRepository;
+    }
+
+    public void createCategory(String name) {
+        MagazineCategory category = MagazineCategory.toEntity(name);
+        magazineCategoryRepository.save(category);
+    }
+
+    public MagazineCategoryResponse.GetAll getAllCategory() {
+        List<MagazineCategory> all = magazineCategoryRepository.findAll();
+        return MagazineCategoryResponse.GetAll.from(all);
+    }
+}

--- a/src/main/java/com/example/codebase/domain/magazine/service/MagazineCategoryService.java
+++ b/src/main/java/com/example/codebase/domain/magazine/service/MagazineCategoryService.java
@@ -25,4 +25,9 @@ public class MagazineCategoryService {
         List<MagazineCategory> all = magazineCategoryRepository.findAll();
         return MagazineCategoryResponse.GetAll.from(all);
     }
+
+    public MagazineCategory getEntity(Long categoryId) {
+        return magazineCategoryRepository.findById(categoryId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 카테고리가 존재하지 않습니다."));
+    }
 }

--- a/src/main/java/com/example/codebase/domain/magazine/service/MagazineService.java
+++ b/src/main/java/com/example/codebase/domain/magazine/service/MagazineService.java
@@ -6,6 +6,7 @@ import com.example.codebase.domain.magazine.entity.Magazine;
 import com.example.codebase.domain.magazine.entity.MagazineCategory;
 import com.example.codebase.domain.magazine.repository.MagazineRepository;
 import com.example.codebase.domain.member.entity.Member;
+import com.example.codebase.exception.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -32,7 +33,7 @@ public class MagazineService {
 
     public MagazineResponse.Get get(Long id) {
         Magazine magazine = magazineRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 매거진이 존재하지 않습니다."));
+                .orElseThrow(() -> new NotFoundException("해당 매거진이 존재하지 않습니다."));
         return MagazineResponse.Get.from(magazine);
     }
 
@@ -44,16 +45,17 @@ public class MagazineService {
     @Transactional
     public void delete(String loginUsername, Long id) {
         Magazine magazine = magazineRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 매거진이 존재하지 않습니다."));
+                .orElseThrow(() -> new NotFoundException("해당 매거진이 존재하지 않습니다."));
 
         isOwner(loginUsername, magazine);
 
         magazineRepository.deleteById(id);
     }
+
     @Transactional
     public MagazineResponse.Get update(Long id, String loginUsername, MagazineRequest.Update magazineRequest) {
         Magazine magazine = magazineRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 매거진이 존재하지 않습니다."));
+                .orElseThrow(() -> new NotFoundException("해당 매거진이 존재하지 않습니다."));
 
         isOwner(loginUsername, magazine);
 

--- a/src/main/java/com/example/codebase/domain/magazine/service/MagazineService.java
+++ b/src/main/java/com/example/codebase/domain/magazine/service/MagazineService.java
@@ -1,0 +1,70 @@
+package com.example.codebase.domain.magazine.service;
+
+import com.example.codebase.domain.magazine.dto.MagazineRequest;
+import com.example.codebase.domain.magazine.dto.MagazineResponse;
+import com.example.codebase.domain.magazine.entity.Magazine;
+import com.example.codebase.domain.magazine.entity.MagazineCategory;
+import com.example.codebase.domain.magazine.repository.MagazineRepository;
+import com.example.codebase.domain.member.entity.Member;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class MagazineService {
+
+    private final MagazineRepository magazineRepository;
+
+    @Autowired
+    public MagazineService(MagazineRepository magazineRepository) {
+        this.magazineRepository = magazineRepository;
+    }
+
+    @Transactional
+    public MagazineResponse.Get create(MagazineRequest.Create magazineRequest, Member member, MagazineCategory category) {
+        Magazine newMagazine = Magazine.toEntity(magazineRequest, member, category);
+        magazineRepository.save(newMagazine);
+        return MagazineResponse.Get.from(newMagazine);
+    }
+
+    public MagazineResponse.Get get(Long id) {
+        Magazine magazine = magazineRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 매거진이 존재하지 않습니다."));
+        return MagazineResponse.Get.from(magazine);
+    }
+
+    public MagazineResponse.GetAll getAll(PageRequest pageRequest) {
+        Page<Magazine> magazines = magazineRepository.findAll(pageRequest);
+        return MagazineResponse.GetAll.from(magazines);
+    }
+
+    @Transactional
+    public void delete(String loginUsername, Long id) {
+        Magazine magazine = magazineRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 매거진이 존재하지 않습니다."));
+
+        isOwner(loginUsername, magazine);
+
+        magazineRepository.deleteById(id);
+    }
+    @Transactional
+    public MagazineResponse.Get update(Long id, String loginUsername, MagazineRequest.Update magazineRequest) {
+        Magazine magazine = magazineRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 매거진이 존재하지 않습니다."));
+
+        isOwner(loginUsername, magazine);
+
+        magazine.update(magazineRequest);
+        magazineRepository.save(magazine);
+        return MagazineResponse.Get.from(magazine);
+    }
+
+    private void isOwner(String loginUsername, Magazine magazine) {
+        if (!magazine.isOwner(loginUsername)) {
+            throw new IllegalArgumentException("해당 매거진의 소유자가 아닙니다.");
+        }
+    }
+}

--- a/src/main/java/com/example/codebase/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/codebase/domain/member/service/MemberService.java
@@ -358,4 +358,9 @@ public class MemberService {
     public List<String> getAllUsername() {
         return memberRepository.findAllUsername();
     }
+
+    public Member getEntity(String username) {
+        return memberRepository.findByUsername(username)
+                .orElseThrow(NotFoundMemberException::new);
+    }
 }

--- a/src/main/resources/db/migration/V202402061800__create_magazine_and_category_table.sql
+++ b/src/main/resources/db/migration/V202402061800__create_magazine_and_category_table.sql
@@ -1,0 +1,26 @@
+CREATE TABLE `magazine_category`
+(
+    `category_id`  bigint       NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `name`         varchar(255) NOT NULL,
+    `is_deleted`   tinyint      NOT NULL DEFAULT 0,
+    `created_time` datetime     NOT NULL,
+    `updated_time` datetime     NOT NULL
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4;
+
+CREATE TABLE `magazine`
+(
+    `magazine_id`  bigint       NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `title`        varchar(255) NOT NULL,
+    `content`      text         NOT NULL,
+    `views`        int          NOT NULL DEFAULT 0,
+    `likes`        int          NOT NULL DEFAULT 0,
+    `is_deleted`   tinyint      NOT NULL DEFAULT 0,
+    `created_time` datetime     NOT NULL,
+    `updated_time` datetime     NOT NULL,
+    `member_id`    binary(16) NOT NULL,
+    `category_id`  bigint       NOT NULL,
+    FOREIGN KEY (`member_id`) REFERENCES `member` (`member_id`),
+    FOREIGN KEY (`category_id`) REFERENCES `magazine_category` (`category_id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4;

--- a/src/main/resources/db/migration/V202402061801__create_magazine_media_table.sql
+++ b/src/main/resources/db/migration/V202402061801__create_magazine_media_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `magazine_media`
+(
+    `magazine_media_id` bigint       NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `media_type`              varchar(50)  NOT NULL,
+    `media_url`               varchar(512) NOT NULL,
+    `is_deleted`        tinyint(1)   NOT NULL DEFAULT 0,
+    `created_time`      datetime     NOT NULL,
+    `updated_time`      datetime     NOT NULL,
+    `magazine_id`       bigint       NOT NULL,
+    `member_id`         binary(16)   NOT NULL,
+    FOREIGN KEY (`magazine_id`) REFERENCES `magazine` (`magazine_id`),
+    FOREIGN KEY (`member_id`) REFERENCES `member` (`member_id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4;

--- a/src/main/resources/db/migration/V202402061802__create_magazine_like_member_table.sql
+++ b/src/main/resources/db/migration/V202402061802__create_magazine_like_member_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `magazine_like_member`
+(
+    `magazine_id` bigint     NOT NULL,
+    `member_id`   binary(16) NOT NULL,
+    `liked_time`  datetime   NOT NULL,
+    PRIMARY KEY (`magazine_id`, `member_id`),
+    FOREIGN KEY (`magazine_id`) REFERENCES `magazine` (`magazine_id`),
+    FOREIGN KEY (`member_id`) REFERENCES `member` (`member_id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4;

--- a/src/main/resources/db/migration/V202402061803__create_magazine_comment.sql
+++ b/src/main/resources/db/migration/V202402061803__create_magazine_comment.sql
@@ -1,0 +1,16 @@
+
+CREATE TABLE `magazine_comment`
+(
+    `magazine_comment_id` bigint     NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `comment`             text       NOT NULL,
+    `is_deleted`          tinyint    NOT NULL DEFAULT 0,
+    `created_time`        datetime   NOT NULL,
+    `updated_time`        datetime   NOT NULL,
+    `member_id`           binary(16) NOT NULL,
+    `magazine_id`         bigint     NOT NULL,
+    `parent_comment_id`   bigint     NOT NULL,
+    FOREIGN KEY (`member_id`) REFERENCES `member` (`member_id`),
+    FOREIGN KEY (`magazine_id`) REFERENCES `magazine` (`magazine_id`),
+    FOREIGN KEY (`parent_comment_id`) REFERENCES `magazine_comment` (`magazine_comment_id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4;

--- a/src/main/resources/db/migration/V202402071500__add_comments_column_to_magazine.sql
+++ b/src/main/resources/db/migration/V202402071500__add_comments_column_to_magazine.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `magazine`
+    ADD COLUMN `comments` int NOT NULL DEFAULT 0 AFTER `likes`;

--- a/src/test/java/com/example/codebase/controller/AgoraControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/AgoraControllerTest.java
@@ -922,7 +922,7 @@ class AgoraControllerTest {
                 get("/api/agoras/" + agora.getId())
             )
             .andDo(print())
-            .andExpect(status().isBadRequest());
+            .andExpect(status().isNotFound());
     }
 
     @WithMockCustomUser(username = "testid", role = "USER")

--- a/src/test/java/com/example/codebase/controller/ArtworkControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/ArtworkControllerTest.java
@@ -20,6 +20,7 @@ import com.example.codebase.s3.S3Service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.findify.s3mock.S3Mock;
+import jakarta.transaction.Transactional;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,7 +36,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-import jakarta.transaction.Transactional;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -1018,7 +1018,7 @@ class ArtworkControllerTest {
                 get("/api/artworks/" + artwork1.getId())
             )
             .andDo(print())
-            .andExpect(status().isBadRequest());
+            .andExpect(status().isNotFound());
     }
 
 
@@ -1167,7 +1167,7 @@ class ArtworkControllerTest {
                 get("/api/artworks/" + artwork.getId())
             )
             .andDo(print())
-            .andExpect(status().isBadRequest());
+            .andExpect(status().isNotFound());
     }
 
     @WithMockCustomUser(username = "testid", role = "USER")

--- a/src/test/java/com/example/codebase/controller/EventControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/EventControllerTest.java
@@ -468,7 +468,7 @@ public class EventControllerTest {
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(dto)))
                 .andDo(print())
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isNotFound());
     }
 
     @WithMockCustomUser(username = "testid", role = "USER")

--- a/src/test/java/com/example/codebase/controller/MagazineCategoryControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/MagazineCategoryControllerTest.java
@@ -19,7 +19,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.util.List;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;

--- a/src/test/java/com/example/codebase/controller/MagazineCategoryControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/MagazineCategoryControllerTest.java
@@ -1,0 +1,104 @@
+package com.example.codebase.controller;
+
+import com.example.codebase.domain.auth.WithMockCustomUser;
+import com.example.codebase.domain.magazine.dto.MagazineCategoryResponse;
+import com.example.codebase.domain.magazine.service.MagazineCategoryService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+@Slf4j
+class MagazineCategoryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private MagazineCategoryService magazineCategoryService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    public void setUp() {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+        objectMapper.registerModule(new JavaTimeModule());
+    }
+
+    @WithMockCustomUser(username = "admin", role = "ADMIN")
+    @DisplayName("매거진 카테고리 생성이 된다.")
+    @Test
+    public void createCategory() throws Exception {
+        // given
+        String name = "글";
+
+        // when
+        mockMvc.perform(
+                        post("/api/magazine-category")
+                                .param("name", name)
+                )
+                .andDo(print())
+                .andExpect(status().isCreated());
+
+        // then
+        MagazineCategoryResponse.GetAll allCategory = magazineCategoryService.getAllCategory();
+        assertTrue(allCategory.getCategories().stream()
+                .anyMatch(category -> category.getName().equals(name)));
+    }
+
+    @DisplayName("매거진 카테고리 전체가 조회 된다.")
+    @Test
+    public void getCategories() throws Exception {
+        // given
+        List<String> categoryNames = List.of("글", "IT", "사진");
+        magazineCategoryService.createCategory(categoryNames.get(0));
+        magazineCategoryService.createCategory(categoryNames.get(1));
+        magazineCategoryService.createCategory(categoryNames.get(2));
+        magazineCategoryService.createCategory("음악");
+
+        // when
+        String response = mockMvc.perform(
+                        get("/api/magazine-category")
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse().getContentAsString(); // json
+
+        // then
+        MagazineCategoryResponse.GetAll allCategory = objectMapper.readValue(response, MagazineCategoryResponse.GetAll.class); // json to object (역직렬화)
+        assertTrue(allCategory.getCategories().stream()
+                .anyMatch(category -> categoryNames.contains(category.getName())));
+    }
+
+}

--- a/src/test/java/com/example/codebase/controller/MagazineControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/MagazineControllerTest.java
@@ -1,0 +1,315 @@
+package com.example.codebase.controller;
+
+import com.example.codebase.domain.auth.WithMockCustomUser;
+import com.example.codebase.domain.magazine.dto.MagazineCategoryRequest;
+import com.example.codebase.domain.magazine.dto.MagazineCategoryResponse;
+import com.example.codebase.domain.magazine.dto.MagazineRequest;
+import com.example.codebase.domain.magazine.dto.MagazineResponse;
+import com.example.codebase.domain.magazine.entity.Magazine;
+import com.example.codebase.domain.magazine.entity.MagazineCategory;
+import com.example.codebase.domain.magazine.service.MagazineCategoryService;
+import com.example.codebase.domain.magazine.service.MagazineService;
+import com.example.codebase.domain.member.dto.CreateMemberDTO;
+import com.example.codebase.domain.member.entity.Authority;
+import com.example.codebase.domain.member.entity.Member;
+import com.example.codebase.domain.member.entity.MemberAuthority;
+import com.example.codebase.domain.member.service.MemberService;
+import com.example.codebase.exception.NotFoundException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+@Slf4j
+class MagazineControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private MagazineCategoryService magazineCategoryService;
+
+    @Autowired
+    private MagazineService magazineService;
+
+    @Autowired
+    private MemberService memberService;
+    
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    public void setUp() {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+        objectMapper.registerModule(new JavaTimeModule());
+    }
+    
+    @Transactional
+    public Member createMember(String username) {
+        CreateMemberDTO createMemberDTO = new CreateMemberDTO();
+        createMemberDTO.setUsername(username);
+        createMemberDTO.setPassword("password");
+        createMemberDTO.setName("name");
+        createMemberDTO.setEmail("email");
+        createMemberDTO.setAllowEmailReceive(true);
+        
+        memberService.createMember(createMemberDTO);
+        return memberService.getEntity(username);
+    }
+
+    @Transactional
+    public MagazineResponse.Get createMagaizne(Member member) {
+        MagazineCategory category = createCategory();
+
+        MagazineRequest.Create magazineRequest = new MagazineRequest.Create();
+        magazineRequest.setTitle("제목");
+        magazineRequest.setContent("내용");
+        magazineRequest.setCategoryId(category.getId());
+
+        return magazineService.create(magazineRequest, member, category);
+    }
+
+    @Transactional
+    public MagazineCategory createCategory() {
+        MagazineCategoryResponse.Get category = magazineCategoryService.createCategory("카테고리");
+        return magazineCategoryService.getEntity(category.getId());
+    }
+
+    @WithMockCustomUser(username = "testid", role = "USER")
+    @DisplayName("매거진 생성이 된다.")
+    @Test
+    void 매거진_생성 () throws Exception {
+        // given
+        createMember("testid");
+        MagazineCategoryResponse.Get category = magazineCategoryService.createCategory("글");
+
+        MagazineRequest.Create magazineRequest = new MagazineRequest.Create();
+        magazineRequest.setTitle("제목");
+        magazineRequest.setContent("내용");
+        magazineRequest.setCategoryId(category.getId());
+
+        // when
+        String response = mockMvc.perform(
+                        post("/api/magazines")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(magazineRequest))
+                )
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        // then
+        MagazineResponse.Get magazine = objectMapper.readValue(response, MagazineResponse.Get.class);
+        assertTrue(magazine.getId() > 0);
+        assertEquals(magazine.getTitle(), magazineRequest.getTitle());
+        assertEquals(magazine.getContent(), magazineRequest.getContent());
+    }
+
+    @WithMockCustomUser(username = "testid", role = "USER")
+    @DisplayName("매거진 생성시 카테고리가 없으면 400.")
+    @Test
+    void 매거진_생성_에러 () throws Exception {
+        // given
+        createMember("testid");
+        MagazineRequest.Create magazineRequest = new MagazineRequest.Create();
+        magazineRequest.setTitle("제목");
+        magazineRequest.setContent("내용");
+        magazineRequest.setCategoryId(0L);
+
+        // when
+        String content = mockMvc.perform(
+                        post("/api/magazines")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(magazineRequest))
+                )
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        // then
+        assertTrue(content.contains("해당 카테고리가 존재하지 않습니다.")); // TODO 에러 메시지를 한곳에서 관리할 필요가 있을듯
+    }
+
+    @DisplayName("매거진 전체 조회가 된다.")
+    @Test
+    void 매거진_전체_조회 () throws Exception {
+        // given
+        Member author = createMember("testid");
+        createMagaizne(author);
+        createMagaizne(author);
+        createMagaizne(author);
+        createMagaizne(author);
+
+        // when
+        String response = mockMvc.perform(
+                        get("/api/magazines")
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        // then
+        MagazineResponse.GetAll magazineList = objectMapper.readValue(response, MagazineResponse.GetAll.class);
+        assertTrue(!magazineList.getMagazines().isEmpty());
+    }
+
+    @DisplayName("매거진 상세 조회가 된다.")
+    @Test
+    void 매거진_상세_조회 () throws Exception {
+        // given
+        Member author = createMember("testid");
+        MagazineResponse.Get magazine = createMagaizne(author);
+
+        // when
+        String response = mockMvc.perform(
+                        get("/api/magazines/" + magazine.getId())
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        // then
+        MagazineResponse.Get magazineResponse = objectMapper.readValue(response, MagazineResponse.Get.class);
+        assertEquals(magazine.getId(), magazineResponse.getId());
+        assertEquals(magazine.getTitle(), magazineResponse.getTitle());
+        assertEquals(magazine.getContent(), magazineResponse.getContent());
+    }
+
+    @DisplayName("매거진 상세 조회시 없는 매거진이면 404.")
+    @Test
+    void 매거진_상세_조회_에러 () throws Exception {
+        // when
+        String content = mockMvc.perform(
+                        get("/api/magazines/0")
+                )
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        // then
+        assertTrue(content.contains("해당 매거진이 존재하지 않습니다."));
+    }
+
+    @WithMockCustomUser(username = "testid", role = "USER")
+    @DisplayName("매거진 수정이 된다.")
+    @Test
+    void 매거진_수정 () throws Exception {
+        // given
+        Member author = createMember("testid");
+        MagazineResponse.Get magazine = createMagaizne(author);
+
+        MagazineRequest.Update magazineRequest = new MagazineRequest.Update();
+        magazineRequest.setTitle("수정된 제목");
+        magazineRequest.setContent("수정된 내용");
+
+        // when
+        String response = mockMvc.perform(
+                        put("/api/magazines/" + magazine.getId())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(magazineRequest))
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        // then
+        MagazineResponse.Get magazineResponse = objectMapper.readValue(response, MagazineResponse.Get.class);
+        assertEquals(magazine.getId(), magazineResponse.getId());
+        assertEquals(magazineRequest.getTitle(), magazineResponse.getTitle());
+        assertEquals(magazineRequest.getContent(), magazineResponse.getContent());
+    }
+
+    @WithMockCustomUser(username = "testid", role = "USER")
+    @DisplayName("매거진 수정시 없는 매거진이면 404.")
+    @Test
+    void 매거진_수정_에러 () throws Exception {
+        // given
+        MagazineRequest.Update magazineRequest = new MagazineRequest.Update();
+        magazineRequest.setTitle("수정된 제목");
+        magazineRequest.setContent("수정된 내용");
+
+        // when
+        String content = mockMvc.perform(
+                        put("/api/magazines/0")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(magazineRequest))
+                )
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        // then
+        assertTrue(content.contains("해당 매거진이 존재하지 않습니다."));
+    }
+
+    @WithMockCustomUser(username = "testid", role = "USER")
+    @DisplayName("매거진 삭제가 된다.")
+    @Test
+    void 매거진_삭제 () throws Exception {
+        // given
+        Member author = createMember("testid");
+        MagazineResponse.Get magazine = createMagaizne(author);
+
+        // when
+        mockMvc.perform(
+                        delete("/api/magazines/" + magazine.getId())
+                )
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        // then
+        assertThrows(NotFoundException.class, () -> magazineService.get(magazine.getId())); // 삭제된 매거진 조회시 404 에러 발생 확인 (삭제됨)
+    }
+
+    @WithMockCustomUser(username = "testid", role = "USER")
+    @DisplayName("매거진 삭제시 없는 매거진이면 404.")
+    @Test
+    void 매거진_삭제_에러 () throws Exception {
+        // when
+        String content = mockMvc.perform(
+                        delete("/api/magazines/0")
+                )
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        // then
+        assertTrue(content.contains("해당 매거진이 존재하지 않습니다."));
+    }
+
+
+
+}


### PR DESCRIPTION
- 매거진 카테고리 생성, 조회 API 구현
- 매거진 CRUD API 구현
- 매거진 관련 통합 테스트 작성
- 매거진 DTO 유지보수를 위해 중첩 클래스로 관리 ([MagazineRequest.class](https://github.com/Media-XI/artscope-backend/pull/125/files#diff-aa5e02eca6d1303bccf365c4e750970ecec708e220deffacfb959092ceb1f25a))
- API RBAC 관련 어노테이션 재사용을 위한 새로운 RBAC 어노테이션 구현 ([12d6a82](https://github.com/Media-XI/artscope-backend/pull/125/commits/12d6a8242f326c3b22b1006985a33067b876d023))
  - \@UserOnly, \@AdminOnly, \@UserAndAdminOnly, \@LoginOnly
- NotFoundException 예외 처리를 위한 새로운 ExceptionHandlerAdvice 메소드 구현 [e81a562](https://github.com/Media-XI/artscope-backend/pull/125/commits/e81a5629fc73ef54d53803197cf243d83d2167a6)
   - 이제 해당 예외 발생 시 응답 코드 404 가 반환됩니다. 

이제 매거진으로 데이터 이관 작업 및 추가 확장 기능 개발 예정입니다.