### PR TITLE
 매거진 댓글, 좋아요, 조회수 기능 구현

### DIFF
--- a/src/main/java/com/example/codebase/controller/MagazineCategoryController.java
+++ b/src/main/java/com/example/codebase/controller/MagazineCategoryController.java
@@ -4,6 +4,7 @@ package com.example.codebase.controller;
 import com.example.codebase.annotation.AdminOnly;
 import com.example.codebase.domain.magazine.dto.MagazineCategoryResponse;
 import com.example.codebase.domain.magazine.service.MagazineCategoryService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "매거진 카테고리 API", description = "매거진 카테고리 관련 API")
 @RestController
 @RequestMapping("/api/magazine-category")
 public class MagazineCategoryController {

--- a/src/main/java/com/example/codebase/controller/MagazineController.java
+++ b/src/main/java/com/example/codebase/controller/MagazineController.java
@@ -13,6 +13,7 @@ import com.example.codebase.domain.member.service.MemberService;
 import com.example.codebase.exception.LoginRequiredException;
 import com.example.codebase.util.SecurityUtil;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.PositiveOrZero;
@@ -22,6 +23,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+@Tag(name = "매거진 API", description = "매거진 관련 API")
 @RestController
 @RequestMapping("/api/magazines")
 public class MagazineController {

--- a/src/main/java/com/example/codebase/controller/MagazineController.java
+++ b/src/main/java/com/example/codebase/controller/MagazineController.java
@@ -39,6 +39,7 @@ public class MagazineController {
         this.memberService = memberService;
     }
 
+    @Operation(summary = "매거진 생성")
     @PostMapping
     @UserOnly
     public ResponseEntity createMagazine(
@@ -56,6 +57,7 @@ public class MagazineController {
         return new ResponseEntity(magazine, HttpStatus.CREATED);
     }
 
+    @Operation(summary = "매거진 조회")
     @GetMapping("/{id}")
     public ResponseEntity getMagazine(
             @PathVariable Long id
@@ -65,6 +67,7 @@ public class MagazineController {
         return new ResponseEntity(magazine, HttpStatus.OK);
     }
 
+    @Operation(summary = "매거진 목록 조회")
     @GetMapping
     public ResponseEntity getMagazines(
             @PositiveOrZero @RequestParam(value = "page", defaultValue = "0") int page,
@@ -77,6 +80,7 @@ public class MagazineController {
         return new ResponseEntity(allMagazines, HttpStatus.OK);
     }
 
+    @Operation(summary = "매거진 수정")
     @PatchMapping("/{id}")
     @UserOnly
     public ResponseEntity updateMagazine(
@@ -90,6 +94,7 @@ public class MagazineController {
         return new ResponseEntity(magazine, HttpStatus.OK);
     }
 
+    @Operation(summary = "매거진 삭제")
     @DeleteMapping("/{id}")
     @UserOnly
     public ResponseEntity deleteMagazine(
@@ -98,21 +103,52 @@ public class MagazineController {
         String loginUsername = SecurityUtil.getCurrentUsernameValue();
         magazineService.delete(loginUsername, id);
 
-        return new ResponseEntity("삭제 완료", HttpStatus.OK);
+        return new ResponseEntity(HttpStatus.NO_CONTENT);
     }
 
     @Operation(summary = "매거진에 댓글 달기")
     @PostMapping("/{id}/comments")
     @LoginOnly
-    public ResponseEntity newPostComment(
+    public ResponseEntity newMagazineComment(
             @PathVariable Long id,
             @RequestBody @Valid MagazineCommentRequest.Create newComment
     ) {
         String loginUsername = SecurityUtil.getCurrentUsernameValue();
         Member member = memberService.getEntity(loginUsername);
 
-        MagazineResponse.Get magazine = magazineService.newPostComment(id, member, newComment);
+        MagazineResponse.Get magazine = magazineService.newMagazineComment(id, member, newComment);
 
         return new ResponseEntity(magazine, HttpStatus.CREATED);
+    }
+
+    @LoginOnly
+    @Operation(summary = "매거진 댓글 수정")
+    @PatchMapping("/{id}/comments/{commentId}")
+    public ResponseEntity updateMagazineComment(
+            @PathVariable("id") Long magazineId,
+            @PathVariable("commentId") Long commentId,
+            @RequestBody MagazineCommentRequest.Update updateComment
+    ) {
+        String loginUsername = SecurityUtil.getCurrentUsernameValue();
+        Member member = memberService.getEntity(loginUsername);
+
+        MagazineResponse.Get magazine = magazineService.updateMagazineComment(magazineId, commentId, updateComment, member);
+
+        return new ResponseEntity(magazine, HttpStatus.OK);
+    }
+
+    @LoginOnly
+    @Operation(summary = "매거진 댓글 삭제")
+    @DeleteMapping("/{id}/comments/{commentId}")
+    public ResponseEntity deleteMagazineComment(
+            @PathVariable("id") Long magazineId,
+            @PathVariable("commentId") Long commentId
+    ) {
+        String loginUsername = SecurityUtil.getCurrentUsernameValue();
+        Member member = memberService.getEntity(loginUsername);
+
+        MagazineResponse.Get magazine = magazineService.deleteMagazineComment(magazineId, commentId, member);
+
+        return new ResponseEntity(magazine, HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/example/codebase/controller/MagazineLikeController.java
+++ b/src/main/java/com/example/codebase/controller/MagazineLikeController.java
@@ -1,0 +1,55 @@
+package com.example.codebase.controller;
+
+import com.example.codebase.annotation.LoginOnly;
+import com.example.codebase.domain.magazine.dto.MagazineResponse;
+import com.example.codebase.domain.magazine.service.MagazineLikeService;
+import com.example.codebase.domain.member.entity.Member;
+import com.example.codebase.domain.member.service.MemberService;
+import com.example.codebase.util.SecurityUtil;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/magazines")
+public class MagazineLikeController {
+
+    private final MagazineLikeService magazineLikeService;
+
+    private final MemberService memberService;
+
+    public MagazineLikeController(MagazineLikeService magazineLikeService, MemberService memberService) {
+        this.magazineLikeService = magazineLikeService;
+        this.memberService = memberService;
+    }
+
+    @LoginOnly
+    @PostMapping("/{magazineId}/like")
+    public ResponseEntity like(
+            @PathVariable Long magazineId
+    ) {
+        String loginUsername = SecurityUtil.getCurrentUsernameValue();
+        Member member = memberService.getEntity(loginUsername);
+
+        MagazineResponse.Get magazine = magazineLikeService.like(magazineId, member);
+
+        return new ResponseEntity(magazine, HttpStatus.OK);
+    }
+
+    @LoginOnly
+    @PostMapping("/{magazineId}/unlike")
+    public ResponseEntity unlike(
+            @PathVariable Long magazineId
+    ) {
+        String loginUsername = SecurityUtil.getCurrentUsernameValue();
+        Member member = memberService.getEntity(loginUsername);
+
+        MagazineResponse.Get magazine = magazineLikeService.unlike(magazineId, member);
+
+        return new ResponseEntity(magazine, HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/com/example/codebase/controller/MagazineLikeController.java
+++ b/src/main/java/com/example/codebase/controller/MagazineLikeController.java
@@ -6,6 +6,7 @@ import com.example.codebase.domain.magazine.service.MagazineLikeService;
 import com.example.codebase.domain.member.entity.Member;
 import com.example.codebase.domain.member.service.MemberService;
 import com.example.codebase.util.SecurityUtil;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "매거진 좋아요 API", description = "매거진 좋아요 관련 API")
 @RestController
 @RequestMapping("/api/magazines")
 public class MagazineLikeController {

--- a/src/main/java/com/example/codebase/domain/magazine/dto/MagazineCommentRepsonse.java
+++ b/src/main/java/com/example/codebase/domain/magazine/dto/MagazineCommentRepsonse.java
@@ -1,0 +1,60 @@
+package com.example.codebase.domain.magazine.dto;
+
+import com.example.codebase.domain.magazine.entity.MagazineComment;
+import com.example.codebase.domain.post.dto.PostCommentResponseDTO;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class MagazineCommentRepsonse {
+
+
+    @Getter
+    @Setter
+    @Schema(name = "MagazineCommentResponse.Get", description = "매거진 댓글 생성 응답")
+    public static class Get {
+
+        private Long id;
+
+        private String comment;
+
+        private String mentionUsername;
+
+        private Integer comments;
+
+        private AuthorResponse author;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        private LocalDateTime createdTime;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        private LocalDateTime updatedTime;
+
+        private Long parentCommentId;
+
+        private List<Get> childComments;
+
+        public static Get from(MagazineComment magazineComment) {
+            Get response = new Get();
+            response.id = magazineComment.getId();
+            response.comment = magazineComment.getComment();
+            response.mentionUsername = magazineComment.getMentionUsername();
+            response.comments = magazineComment.getComments();
+            response.author = AuthorResponse.from(magazineComment.getMember());
+            response.createdTime = magazineComment.getCreatedTime();
+            response.updatedTime = magazineComment.getUpdatedTime();
+
+            // 자식 댓글들 DTO로 추가
+            response.parentCommentId = magazineComment.getParentCommentId();
+            response.childComments = magazineComment.getChildComments().stream()
+                    .map(MagazineCommentRepsonse.Get::from)
+                    .toList();
+            return response;
+        }
+    }
+}

--- a/src/main/java/com/example/codebase/domain/magazine/dto/MagazineCommentRequest.java
+++ b/src/main/java/com/example/codebase/domain/magazine/dto/MagazineCommentRequest.java
@@ -14,10 +14,17 @@ public class MagazineCommentRequest {
     @Schema(name = "MagazineCommentRequest.Create", description = "매거진 댓글 생성 DTO")
     public static class Create {
 
-        @NotEmpty
+        @NotEmpty(message = "댓글 내용을 작성해주세요.")
         private String comment;
 
         private Long parentCommentId;
     }
 
+    @Getter
+    @Setter
+    @Schema(name = "MagazineCommentRequest.Update", description = "매거진 댓글 수정 DTO")
+    public static class Update {
+        @NotEmpty(message = "댓글 내용을 작성해주세요.")
+        private String comment;
+    }
 }

--- a/src/main/java/com/example/codebase/domain/magazine/dto/MagazineCommentRequest.java
+++ b/src/main/java/com/example/codebase/domain/magazine/dto/MagazineCommentRequest.java
@@ -1,0 +1,23 @@
+package com.example.codebase.domain.magazine.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Null;
+import lombok.Getter;
+import lombok.Setter;
+import net.minidev.json.annotate.JsonIgnore;
+
+public class MagazineCommentRequest {
+
+    @Getter
+    @Setter
+    @Schema(name = "MagazineCommentRequest.Create", description = "매거진 댓글 생성 DTO")
+    public static class Create {
+
+        @NotEmpty
+        private String comment;
+
+        private Long parentCommentId;
+    }
+
+}

--- a/src/main/java/com/example/codebase/domain/magazine/dto/MagazineRequest.java
+++ b/src/main/java/com/example/codebase/domain/magazine/dto/MagazineRequest.java
@@ -1,8 +1,9 @@
 package com.example.codebase.domain.magazine.dto;
 
-import com.example.codebase.domain.magazine.entity.Magazine;
-import com.example.codebase.domain.magazine.entity.MagazineCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Null;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -13,10 +14,13 @@ public class MagazineRequest {
     @Schema(name = "MagazineRequest.Create", description = "매거진 생성 DTO")
     public static class Create {
 
+        @NotEmpty
         private String title;
 
+        @NotEmpty
         private String content;
 
+        @NotNull
         private Long categoryId;
     }
 
@@ -25,8 +29,10 @@ public class MagazineRequest {
     @Schema(name = "MagazineRequest.Update", description = "매거진 수정 DTO")
     public static class Update {
 
+        @NotEmpty
         private String title;
 
+        @NotEmpty
         private String content;
 
     }

--- a/src/main/java/com/example/codebase/domain/magazine/entity/Magazine.java
+++ b/src/main/java/com/example/codebase/domain/magazine/entity/Magazine.java
@@ -10,6 +10,8 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Where;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "magazine")
@@ -59,6 +61,10 @@ public class Magazine {
     @JoinColumn(name = "category_id")
     private MagazineCategory category;
 
+    @Builder.Default
+    @OneToMany(mappedBy = "magazine", cascade = CascadeType.ALL)
+    private List<MagazineComment> magazineComments = new ArrayList<>();
+
     public static Magazine toEntity(MagazineRequest.Create magazineRequest, Member member, MagazineCategory category) {
         return Magazine.builder()
                 .title(magazineRequest.getTitle())
@@ -78,5 +84,14 @@ public class Magazine {
         this.title = magazineRequest.getTitle();
         this.content = magazineRequest.getContent();
         this.updatedTime = LocalDateTime.now();
+    }
+
+    public void incressView() {
+        this.views++;
+    }
+
+    public void addComment(MagazineComment entity) {
+        this.magazineComments.add(entity);
+        this.comments = this.magazineComments.size();
     }
 }

--- a/src/main/java/com/example/codebase/domain/magazine/entity/Magazine.java
+++ b/src/main/java/com/example/codebase/domain/magazine/entity/Magazine.java
@@ -65,6 +65,10 @@ public class Magazine {
     @OneToMany(mappedBy = "magazine", cascade = CascadeType.ALL)
     private List<MagazineComment> magazineComments = new ArrayList<>();
 
+    @Builder.Default
+    @OneToMany(mappedBy = "magazine", cascade = CascadeType.ALL)
+    private List<MagazineLike> magazineLikes = new ArrayList<>();
+
     public static Magazine toEntity(MagazineRequest.Create magazineRequest, Member member, MagazineCategory category) {
         return Magazine.builder()
                 .title(magazineRequest.getTitle())
@@ -100,5 +104,15 @@ public class Magazine {
         this.updatedTime = LocalDateTime.now();
         // 양방향 매핑 제거
         this.magazineComments.clear();
+    }
+
+    public void addLike(MagazineLike magazineLike) {
+        this.magazineLikes.add(magazineLike);
+        this.likes = this.magazineLikes.size();
+    }
+
+    public void removeLike(MagazineLike magazineLike) {
+        this.magazineLikes.remove(magazineLike);
+        this.likes = this.magazineLikes.size();
     }
 }

--- a/src/main/java/com/example/codebase/domain/magazine/entity/Magazine.java
+++ b/src/main/java/com/example/codebase/domain/magazine/entity/Magazine.java
@@ -94,4 +94,11 @@ public class Magazine {
         this.magazineComments.add(entity);
         this.comments = this.magazineComments.size();
     }
+
+    public void delete() {
+        this.isDeleted = true;
+        this.updatedTime = LocalDateTime.now();
+        // 양방향 매핑 제거
+        this.magazineComments.clear();
+    }
 }

--- a/src/main/java/com/example/codebase/domain/magazine/entity/MagazineComment.java
+++ b/src/main/java/com/example/codebase/domain/magazine/entity/MagazineComment.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -19,6 +20,7 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@Where(clause = "is_deleted = false")
 public class MagazineComment {
 
     @Id
@@ -114,5 +116,31 @@ public class MagazineComment {
 
     public Long getParentCommentId() {
         return this.parentComment == null ? null : this.parentComment.getId();
+    }
+
+    public Boolean isCommentAuthor(Member member) {
+        return this.member == member;
+    }
+
+    public void update(MagazineCommentRequest.Update updateComment) {
+        this.comment = updateComment.getComment();
+        this.updatedTime = LocalDateTime.now();
+    }
+
+
+    /**
+     * 댓글 삭제
+     * SOFT DELETE
+     * 매거진 양방향 매핑 해제
+     */
+    public void delete() {
+        this.isDeleted = true;
+        this.updatedTime = LocalDateTime.now();
+        // 매거진 양방향 매핑 해제
+        this.magazine.getMagazineComments().remove(this);
+        // 부모댓글이 존재할 경우 양방향 매핑 해제
+        if (hasParentComment()) {
+            this.parentComment.getChildComments().remove(this);
+        }
     }
 }

--- a/src/main/java/com/example/codebase/domain/magazine/entity/MagazineComment.java
+++ b/src/main/java/com/example/codebase/domain/magazine/entity/MagazineComment.java
@@ -1,0 +1,118 @@
+package com.example.codebase.domain.magazine.entity;
+
+import com.example.codebase.domain.magazine.dto.MagazineCommentRequest;
+import com.example.codebase.domain.magazine.dto.MagazineRequest;
+import com.example.codebase.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "magazine_comment")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MagazineComment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "magazine_comment_id")
+    private Long id;
+
+    @Column(name = "comment")
+    private String comment;
+
+    @Column(name = "mention_username")
+    private String mentionUsername;
+
+    @Builder.Default
+    @Column(name = "likes")
+    private Integer likes = 0;
+
+    @Builder.Default
+    @Column(name = "comments")
+    private Integer comments = 0;
+
+    @Builder.Default
+    @Column(name = "is_deleted")
+    private Boolean isDeleted = false;
+
+    @Builder.Default
+    @Column(name = "created_time")
+    private LocalDateTime createdTime = LocalDateTime.now();
+
+    @Builder.Default
+    @Column(name = "updated_time")
+    private LocalDateTime updatedTime = LocalDateTime.now();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "magazine_id")
+    private Magazine magazine;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_comment_id")
+    private MagazineComment parentComment;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "parentComment", fetch = FetchType.LAZY)
+    private List<MagazineComment> childComments = new ArrayList<>();
+
+    public static MagazineComment toEntity(MagazineCommentRequest.Create newComment, Member member, Magazine magazine) {
+        MagazineComment entity = MagazineComment.builder()
+                .comment(newComment.getComment())
+                .member(member)
+                .build();
+        // 매거진 양방향 매핑
+        entity.setMagazine(magazine);
+        return entity;
+    }
+
+    private void setMagazine(Magazine magazine) {
+        if (this.magazine != null) {
+            this.magazine.getMagazineComments().remove(this);
+        }
+        this.magazine = magazine;
+        magazine.addComment(this);
+    }
+
+    public void mentionComment(MagazineComment mentionTarget) {
+        this.mentionUsername = mentionTarget.getUsername();
+        setParentComment(mentionTarget.getParentComment());
+    }
+
+    private String getUsername() {
+        return this.getMember().getUsername();
+    }
+
+    public void setParentComment(MagazineComment parentComment) {
+        if (hasParentComment()) {
+            this.parentComment.childComments.remove(this);
+        }
+        this.parentComment = parentComment;
+        parentComment.addChildComment(this);
+    }
+
+    public boolean hasParentComment() {
+        return this.parentComment != null;
+    }
+
+    private void addChildComment(MagazineComment childComment) {
+        this.childComments.add(childComment);
+        this.comments = this.childComments.size(); // 댓글 수 업데이트
+    }
+
+    public Long getParentCommentId() {
+        return this.parentComment == null ? null : this.parentComment.getId();
+    }
+}

--- a/src/main/java/com/example/codebase/domain/magazine/entity/MagazineLike.java
+++ b/src/main/java/com/example/codebase/domain/magazine/entity/MagazineLike.java
@@ -1,0 +1,43 @@
+package com.example.codebase.domain.magazine.entity;
+
+import com.example.codebase.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "magazine_like")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MagazineLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "magazine_like_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "magazine_id")
+    private Magazine magazine;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", columnDefinition = "BINARY(16)")
+    private Member member;
+
+    @Builder.Default
+    @Column(name = "liked_time")
+    private LocalDateTime likedTime = LocalDateTime.now();
+    
+    public static MagazineLike toEntity(Magazine magazine, Member member) {
+        return MagazineLike.builder()
+                .magazine(magazine)
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/com/example/codebase/domain/magazine/repository/MagazineCommentRepository.java
+++ b/src/main/java/com/example/codebase/domain/magazine/repository/MagazineCommentRepository.java
@@ -1,0 +1,17 @@
+package com.example.codebase.domain.magazine.repository;
+
+import com.example.codebase.domain.magazine.entity.Magazine;
+import com.example.codebase.domain.magazine.entity.MagazineComment;
+import com.example.codebase.domain.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MagazineCommentRepository extends JpaRepository<MagazineComment, Long> {
+
+    Optional<MagazineComment> findByIdAndMagazine(Long parentCommentId, Magazine magazine);
+
+
+    List<MagazineComment> findByMagazine(Magazine magazine);
+}

--- a/src/main/java/com/example/codebase/domain/magazine/repository/MagazineLikeRepository.java
+++ b/src/main/java/com/example/codebase/domain/magazine/repository/MagazineLikeRepository.java
@@ -1,0 +1,15 @@
+package com.example.codebase.domain.magazine.repository;
+
+import com.example.codebase.domain.magazine.entity.Magazine;
+import com.example.codebase.domain.magazine.entity.MagazineLike;
+import com.example.codebase.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface MagazineLikeRepository extends JpaRepository<MagazineLike, Long> {
+
+    @Query("select ml from MagazineLike ml where ml.magazine = :magazine and ml.member = :member")
+    Optional<MagazineLike> findByIds(Magazine magazine, Member member);
+}

--- a/src/main/java/com/example/codebase/domain/magazine/repository/MagazineRepository.java
+++ b/src/main/java/com/example/codebase/domain/magazine/repository/MagazineRepository.java
@@ -2,6 +2,12 @@ package com.example.codebase.domain.magazine.repository;
 
 import com.example.codebase.domain.magazine.entity.Magazine;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface MagazineRepository extends JpaRepository<Magazine, Long> {
+
+    @Query("SELECT m FROM Magazine m WHERE m.id = :id AND m.isDeleted = false")
+    Optional<Magazine> findById(Long id);
 }

--- a/src/main/java/com/example/codebase/domain/magazine/service/MagazineLikeService.java
+++ b/src/main/java/com/example/codebase/domain/magazine/service/MagazineLikeService.java
@@ -1,0 +1,50 @@
+package com.example.codebase.domain.magazine.service;
+
+import com.example.codebase.domain.magazine.dto.MagazineResponse;
+import com.example.codebase.domain.magazine.entity.Magazine;
+import com.example.codebase.domain.magazine.entity.MagazineLike;
+import com.example.codebase.domain.magazine.repository.MagazineLikeRepository;
+import com.example.codebase.domain.magazine.repository.MagazineRepository;
+import com.example.codebase.domain.member.entity.Member;
+import com.example.codebase.exception.NotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MagazineLikeService {
+
+    private final MagazineLikeRepository magazineLikeRepository;
+
+    private final MagazineRepository magazineRepository;
+
+    public MagazineLikeService(MagazineLikeRepository magazineLikeRepository, MagazineRepository magazineRepository) {
+        this.magazineLikeRepository = magazineLikeRepository;
+        this.magazineRepository = magazineRepository;
+    }
+
+    @Transactional
+    public MagazineResponse.Get like(Long magazineId, Member member) {
+        Magazine magazine = magazineRepository.findById(magazineId)
+                .orElseThrow(() -> new NotFoundException("해당 매거진을 찾을 수 없습니다."));
+
+        MagazineLike magazineLike = MagazineLike.toEntity(magazine, member);
+        magazine.addLike(magazineLike);
+
+        magazineLikeRepository.save(magazineLike);
+        return MagazineResponse.Get.from(magazine);
+    }
+
+    @Transactional
+    public MagazineResponse.Get unlike(Long magazineId, Member member) {
+        Magazine magazine = magazineRepository.findById(magazineId)
+                .orElseThrow(() -> new NotFoundException("해당 매거진을 찾을 수 없습니다."));
+
+        MagazineLike magazineLike = magazineLikeRepository.findByIds(magazine, member)
+                .orElseThrow(() -> new NotFoundException("해당 좋아요를 찾을 수 없습니다."));
+
+        magazine.removeLike(magazineLike);
+
+        magazineLikeRepository.delete(magazineLike);
+        return MagazineResponse.Get.from(magazine);
+    }
+}

--- a/src/main/java/com/example/codebase/domain/magazine/service/MagazineLikeService.java
+++ b/src/main/java/com/example/codebase/domain/magazine/service/MagazineLikeService.java
@@ -10,6 +10,8 @@ import com.example.codebase.exception.NotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 public class MagazineLikeService {
 
@@ -27,6 +29,13 @@ public class MagazineLikeService {
         Magazine magazine = magazineRepository.findById(magazineId)
                 .orElseThrow(() -> new NotFoundException("해당 매거진을 찾을 수 없습니다."));
 
+        Optional<MagazineLike> like = magazineLikeRepository.findByIds(magazine, member);
+
+        // 좋아요 로직에 대해 멱등성 보장
+        if (like.isPresent()) {
+            return MagazineResponse.Get.from(magazine);
+        }
+
         MagazineLike magazineLike = MagazineLike.toEntity(magazine, member);
         magazine.addLike(magazineLike);
 
@@ -40,7 +49,7 @@ public class MagazineLikeService {
                 .orElseThrow(() -> new NotFoundException("해당 매거진을 찾을 수 없습니다."));
 
         MagazineLike magazineLike = magazineLikeRepository.findByIds(magazine, member)
-                .orElseThrow(() -> new NotFoundException("해당 좋아요를 찾을 수 없습니다."));
+                .orElseThrow(() -> new NotFoundException("좋아요한 매거진이 아닙니다."));
 
         magazine.removeLike(magazineLike);
 

--- a/src/main/java/com/example/codebase/util/SecurityUtil.java
+++ b/src/main/java/com/example/codebase/util/SecurityUtil.java
@@ -3,6 +3,7 @@ package com.example.codebase.util;
 
 import com.example.codebase.domain.auth.dto.TokenResponseDTO;
 import com.example.codebase.domain.member.dto.AuthorityDto;
+import com.example.codebase.exception.LoginRequiredException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -35,6 +36,10 @@ public class SecurityUtil {
         }
 
         return Optional.ofNullable(username);
+    }
+
+    public static String getCurrentUsernameValue() {
+        return getCurrentUsername().orElseThrow(LoginRequiredException::new);
     }
 
     public static boolean isAnonymous() {

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -25,7 +25,8 @@ spring:
     properties:
       hibernate:
         show_sql: true
-      format_sql: true
+        format_sql: true
+        highlight_sql: true
     defer-datasource-initialization: true
   h2:
     console:
@@ -50,6 +51,7 @@ logging:
   level:
     org:
       hibernate:
+        SQL: debug
         type:
           descriptor:
-            sql: trace
+            sql: TRACE

--- a/src/main/resources/db/migration/V202402151700__create_magazine_comment.sql
+++ b/src/main/resources/db/migration/V202402151700__create_magazine_comment.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `magazine_comment`
+(
+    `magazine_comment_id` bigint AUTO_INCREMENT PRIMARY KEY,
+    `comment`             text                               NOT NULL,
+    `mention_username`    varchar(50)                        null,
+    `likes`               int      default 0                 not null,
+    `comments`            int      default 0                 not null,
+    `is_deleted`          tinyint                            NOT NULL DEFAULT 0,
+    `created_time`        datetime default CURRENT_TIMESTAMP not null,
+    `updated_time`        datetime default CURRENT_TIMESTAMP null on update CURRENT_TIMESTAMP,
+    `member_id`           binary(16)                         not null,
+    `magazine_id`         bigint                             not null,
+    `parent_comment_id`   bigint                             null,
+    foreign key (`member_id`) references `member` (`member_id`),
+    foreign key (`magazine_id`) references `magazine` (`magazine_id`),
+    foreign key (`parent_comment_id`) references `magazine_comment` (`magazine_comment_id`)
+)

--- a/src/main/resources/db/migration/V202402291700__create_magazine_like_table.sql
+++ b/src/main/resources/db/migration/V202402291700__create_magazine_like_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `magazine_like` (
+    `magazine_like_id` BIGINT PRIMARY KEY AUTO_INCREMENT,
+    `magazine_id` BIGINT NOT NULL,
+    `member_id` BIGINT NOT NULL,
+    `liked_time` DATETIME NOT NULL,
+    FOREIGN KEY (`magazine_id`) REFERENCES `magazine` (`magazine_id`),
+    FOREIGN KEY (`member_id`) REFERENCES `member` (`member_id`)
+)

--- a/src/test/java/com/example/codebase/controller/MagazineLikeControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/MagazineLikeControllerTest.java
@@ -188,6 +188,30 @@ class MagazineLikeControllerTest {
         assertEquals(0, magazineService.get(magazine.getId()).getLikes());
     }
 
+    @WithMockCustomUser(username = "testid")
+    @DisplayName("매거진 2번 좋아요 시")
+    @Test
+    void 매거진_2번_좋아요() throws Exception {
+
+        // when
+        mockMvc.perform(
+                        post("/api/magazines/{magazineId}/like", magazine.getId())
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        mockMvc.perform(
+                        post("/api/magazines/{magazineId}/like", magazine.getId())
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        // then
+        assertEquals(1, magazineService.get(magazine.getId()).getLikes());
+    }
+
 
 //    @WithMockCustomUser(username = "testid")
 //    @DisplayName("한 유저가 동시에 2회 이상 매거진 좋아요 시, 한 요청만 성공 후 나머지 요청은 실패한다")

--- a/src/test/java/com/example/codebase/controller/MagazineLikeControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/MagazineLikeControllerTest.java
@@ -1,0 +1,221 @@
+package com.example.codebase.controller;
+
+import com.example.codebase.domain.auth.WithMockCustomUser;
+import com.example.codebase.domain.magazine.dto.MagazineCategoryResponse;
+import com.example.codebase.domain.magazine.dto.MagazineRequest;
+import com.example.codebase.domain.magazine.dto.MagazineResponse;
+import com.example.codebase.domain.magazine.entity.Magazine;
+import com.example.codebase.domain.magazine.entity.MagazineCategory;
+import com.example.codebase.domain.magazine.repository.MagazineCategoryRepository;
+import com.example.codebase.domain.magazine.repository.MagazineRepository;
+import com.example.codebase.domain.magazine.service.MagazineCategoryService;
+import com.example.codebase.domain.magazine.service.MagazineLikeService;
+import com.example.codebase.domain.magazine.service.MagazineService;
+import com.example.codebase.domain.member.dto.CreateMemberDTO;
+import com.example.codebase.domain.member.entity.Authority;
+import com.example.codebase.domain.member.entity.Member;
+import com.example.codebase.domain.member.entity.MemberAuthority;
+import com.example.codebase.domain.member.repository.MemberRepository;
+import com.example.codebase.domain.member.service.MemberService;
+import com.example.codebase.jwt.TokenProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Slf4j
+class MagazineLikeControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private MagazineService magazineService;
+
+    @Autowired
+    private MagazineLikeService magazineLikeService;
+
+    @Autowired
+    private MagazineRepository magazineRepository;
+
+    @Autowired
+    private MagazineCategoryRepository magazineCategoryRepository;
+
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    Member member;
+    Magazine magazine;
+
+    @BeforeEach
+    public void setUp() {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+        objectMapper.registerModule(new JavaTimeModule());
+
+        member = createOrLoadMember("testid", "ROLE_USER");
+        magazine = createMagaizne(member);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        magazineRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    public Member createOrLoadMember(String username, String role) {
+        Optional<Member> testMember = memberRepository.findByUsername(username);
+        if (testMember.isPresent()) {
+            return testMember.get();
+        }
+
+        Member dummy = Member.builder()
+                .username(username)
+                .password(passwordEncoder.encode("1234"))
+                .email(username + "@test.com")
+                .name(username)
+                .activated(true)
+                .createdTime(LocalDateTime.now())
+                .build();
+
+        MemberAuthority memberAuthority = new MemberAuthority();
+        memberAuthority.setAuthority(Authority.of(role));
+        memberAuthority.setMember(dummy);
+        dummy.addAuthority(memberAuthority);
+
+        Member save = memberRepository.saveAndFlush(dummy);
+        return save;
+    }
+
+    public Magazine createMagaizne(Member member) {
+        MagazineCategory category = MagazineCategory.builder()
+                .name("카테고리")
+                .build();
+         magazineCategoryRepository.save(category);
+
+        Magazine saved = magazineRepository.saveAndFlush(Magazine.builder()
+                .title("제목")
+                .content("내용")
+                .category(category)
+                .member(member)
+                .build());
+
+        return saved;
+    }
+
+    @WithMockCustomUser(username = "testid")
+    @DisplayName("매거진 좋아요 시")
+    @Test
+    void 매거진_좋아요() throws Exception {
+
+        // when
+        mockMvc.perform(
+                        post("/api/magazines/{magazineId}/like", magazine.getId())
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        // then
+        assertEquals(1, magazineService.get(magazine.getId()).getLikes());
+    }
+
+    @WithMockCustomUser(username = "testid")
+    @DisplayName("매거진 좋아요 취소 시")
+    @Test
+    void 매거진_좋아요_취소() throws Exception {
+        // given
+        magazineLikeService.like(magazine.getId(), member);
+
+        // when
+        mockMvc.perform(
+                        post("/api/magazines/{magazineId}/unlike", magazine.getId())
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        // then
+        assertEquals(0, magazineService.get(magazine.getId()).getLikes());
+    }
+
+
+//    @WithMockCustomUser(username = "testid")
+//    @DisplayName("한 유저가 동시에 2회 이상 매거진 좋아요 시, 한 요청만 성공 후 나머지 요청은 실패한다")
+//    @Test
+//    void 동시_매거진_좋아요() throws Exception {
+//        int threadCount = 10;
+//        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+//        CountDownLatch latch = new CountDownLatch(threadCount);
+//
+//        // when
+//        IntStream.range(0, threadCount).forEach(e -> {
+//            executorService.submit(() -> {
+//                try {
+//                    log.info("Thread {} started", e);
+//                    TransactionStatus transactionStatus = transactionManager.getTransaction(null);
+//                    magazineLikeService.like(magazine.getId(), member);
+//                    transactionManager.commit(transactionStatus);
+//                } finally {
+//                    latch.countDown();
+//                }
+//            });
+//        });
+//        latch.await();
+//
+//        // then
+//        int likes = magazine.getLikes();
+//        assertEquals(1, likes);
+//    }
+
+
+}


### PR DESCRIPTION
- 매거진 댓글 생성, 삭제, 수정 API
- 매거진 좋아요, 좋아요 취소 API
   - 좋아요 API 멱등성 보장 [로직](https://github.com/Media-XI/artscope-backend/pull/128/commits/4a96f162b8ac51e00d412e9217e3c0cbdb93f7c4) 
- 매거진 조회 시 조회수 증가 기능 

## 추후
- 매거진 좋아요, 조회수 수에 대해 동시성 테스트 필요
- 한 유저가 매거진 좋아요 2번 이상 (따닥) 동시에 요청 시 한 요청은 성공하고 나머지 요청에 대해선 실패할 수 있도록 로직 개선 (연달아 요청이 아닌 동시에)
- 매거진 조회 시 좋아요 여부 표시 필요