### PR TITLE
매거진 메타데이터 다이나믹 필드 & 사용자가 작성한 매거진 조회 API

### DIFF
--- a/src/main/java/com/example/codebase/controller/MagazineController.java
+++ b/src/main/java/com/example/codebase/controller/MagazineController.java
@@ -41,7 +41,7 @@ public class MagazineController {
         this.memberService = memberService;
     }
 
-    @Operation(summary = "매거진 생성")
+    @Operation(summary = "매거진 생성", description = "로그인한 사용자만 매거진을 생성할 수 있습니다. 매거진 생성 시 미디어 첨부 가능합니다. 또한 JSON 형식의 메타데이터를 추가할 수 있습니다.")
     @PostMapping
     @UserOnly
     public ResponseEntity createMagazine(
@@ -82,8 +82,8 @@ public class MagazineController {
         return new ResponseEntity(allMagazines, HttpStatus.OK);
     }
 
-    @Operation(summary = "매거진 수정")
-    @PatchMapping("/{id}")
+    @Operation(summary = "매거진 수정", description = "자신의 매거진만 수정 가능합니다. 기존 항목도 모두 업데이트 됩니다.")
+    @PutMapping("/{id}")
     @UserOnly
     public ResponseEntity updateMagazine(
             @PathVariable Long id,

--- a/src/main/java/com/example/codebase/controller/MagazineController.java
+++ b/src/main/java/com/example/codebase/controller/MagazineController.java
@@ -15,7 +15,6 @@ import com.example.codebase.util.SecurityUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.PositiveOrZero;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
@@ -23,6 +22,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
 @Tag(name = "매거진 API", description = "매거진 관련 API")
 @RestController
 @RequestMapping("/api/magazines")
@@ -78,6 +78,22 @@ public class MagazineController {
     ) {
         PageRequest pageRequest = PageRequest.of(page, size, Sort.by(Sort.Direction.fromString(sortDirection), "createdTime"));
         MagazineResponse.GetAll allMagazines = magazineService.getAll(pageRequest);
+
+        return new ResponseEntity(allMagazines, HttpStatus.OK);
+    }
+
+    @Operation(summary = "해당 사용자의 매거진 전체 조회", description = "해당 사용자가 작성한 매거진을 조회합니다. 페이지네이션")
+    @GetMapping("/members/{username}")
+    public ResponseEntity getMyMagazines(
+            @PathVariable String username,
+            @PositiveOrZero @RequestParam(value = "page", defaultValue = "0") int page,
+            @PositiveOrZero @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam(defaultValue = "DESC", required = false) String sortDirection
+    ) {
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by(Sort.Direction.fromString(sortDirection), "createdTime"));
+        Member member = memberService.getEntity(username);
+
+        MagazineResponse.GetAll allMagazines = magazineService.getMemberMagazines(member, pageRequest);
 
         return new ResponseEntity(allMagazines, HttpStatus.OK);
     }

--- a/src/main/java/com/example/codebase/domain/magazine/dto/MagazineRequest.java
+++ b/src/main/java/com/example/codebase/domain/magazine/dto/MagazineRequest.java
@@ -10,6 +10,7 @@ import org.hibernate.validator.constraints.URL;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public class MagazineRequest {
 
@@ -26,6 +27,9 @@ public class MagazineRequest {
 
         @NotNull
         private Long categoryId;
+
+        // TODO: metadata 에 대해 검증 필요 (보안)
+        private Map<String, String> metadata;
 
         @Size(max = 10, message = "최대 10개 까지 미디어 첨부 가능합니다.")
         private List<@URL(message = "올바른 URL 형식이 아닙니다.") String> mediaUrls = Collections.emptyList();

--- a/src/main/java/com/example/codebase/domain/magazine/dto/MagazineRequest.java
+++ b/src/main/java/com/example/codebase/domain/magazine/dto/MagazineRequest.java
@@ -29,6 +29,7 @@ public class MagazineRequest {
         private Long categoryId;
 
         // TODO: metadata 에 대해 검증 필요 (보안)
+        @Schema(description = "JSON 형식의 메타데이터")
         private Map<String, String> metadata;
 
         @Size(max = 10, message = "최대 10개 까지 미디어 첨부 가능합니다.")
@@ -45,6 +46,8 @@ public class MagazineRequest {
 
         @NotEmpty
         private String content;
+
+        private Map<String, String> metadata;
 
         private List<String> mediaUrls;
     }

--- a/src/main/java/com/example/codebase/domain/magazine/dto/MagazineResponse.java
+++ b/src/main/java/com/example/codebase/domain/magazine/dto/MagazineResponse.java
@@ -2,7 +2,6 @@ package com.example.codebase.domain.magazine.dto;
 
 import com.example.codebase.controller.dto.PageInfo;
 import com.example.codebase.domain.magazine.entity.Magazine;
-import com.example.codebase.domain.magazine.entity.MagazineComment;
 import com.example.codebase.domain.magazine.entity.MagazineMedia;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -12,9 +11,9 @@ import lombok.Setter;
 import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public class MagazineResponse {
 
@@ -27,6 +26,8 @@ public class MagazineResponse {
         private String title;
 
         private String content;
+
+        private Map<String, String> metadata;
 
         private String category;
 
@@ -53,6 +54,7 @@ public class MagazineResponse {
             response.id = magazine.getId();
             response.title = magazine.getTitle();
             response.content = magazine.getContent();
+            response.metadata = magazine.getMetadata();
             response.mediaUrls = magazine.getMagazineMedias().stream()
                     .map(MagazineMedia::getUrl)
                     .toList();

--- a/src/main/java/com/example/codebase/domain/magazine/entity/Magazine.java
+++ b/src/main/java/com/example/codebase/domain/magazine/entity/Magazine.java
@@ -7,11 +7,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.Where;
+import org.hibernate.type.SqlTypes;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Entity
 @Table(name = "magazine")
@@ -32,6 +35,10 @@ public class Magazine {
 
     @Column(name = "content", columnDefinition = "TEXT", nullable = false)
     private String content;
+
+    @Column(name = "metadata", columnDefinition = "json")
+    @JdbcTypeCode(SqlTypes.JSON)
+    private Map<String, String> metadata;
 
     @Builder.Default
     @Column(name = "views", columnDefinition = "integer default 0")
@@ -77,6 +84,7 @@ public class Magazine {
         return Magazine.builder()
                 .title(magazineRequest.getTitle())
                 .content(magazineRequest.getContent())
+                .metadata(magazineRequest.getMetadata())
                 .member(member)
                 .category(category)
                 .createdTime(LocalDateTime.now())

--- a/src/main/java/com/example/codebase/domain/magazine/entity/Magazine.java
+++ b/src/main/java/com/example/codebase/domain/magazine/entity/Magazine.java
@@ -99,6 +99,7 @@ public class Magazine {
     public void update(MagazineRequest.Update magazineRequest) {
         this.title = magazineRequest.getTitle();
         this.content = magazineRequest.getContent();
+        this.metadata = magazineRequest.getMetadata();
         this.updatedTime = LocalDateTime.now();
     }
 

--- a/src/main/java/com/example/codebase/domain/magazine/repository/MagazineRepository.java
+++ b/src/main/java/com/example/codebase/domain/magazine/repository/MagazineRepository.java
@@ -1,6 +1,9 @@
 package com.example.codebase.domain.magazine.repository;
 
 import com.example.codebase.domain.magazine.entity.Magazine;
+import com.example.codebase.domain.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -10,4 +13,6 @@ public interface MagazineRepository extends JpaRepository<Magazine, Long> {
 
     @Query("SELECT m FROM Magazine m WHERE m.id = :id AND m.isDeleted = false")
     Optional<Magazine> findById(Long id);
+
+    Page<Magazine> findByMember(Member member, PageRequest pageRequest);
 }

--- a/src/main/java/com/example/codebase/domain/magazine/service/MagazineService.java
+++ b/src/main/java/com/example/codebase/domain/magazine/service/MagazineService.java
@@ -162,4 +162,9 @@ public class MagazineService {
             throw new RuntimeException("댓글 작성자가 아닙니다.");
         }
     }
+
+    public MagazineResponse.GetAll getMemberMagazines(Member member, PageRequest pageRequest) {
+        Page<Magazine> magazines = magazineRepository.findByMember(member, pageRequest);
+        return MagazineResponse.GetAll.from(magazines);
+    }
 }

--- a/src/main/resources/db/migration/V202403041730__add_metadata_column_to_magazine.sql
+++ b/src/main/resources/db/migration/V202403041730__add_metadata_column_to_magazine.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `magazine`
+    ADD `metadata` JSON NULL DEFAULT NULL AFTER `content`,

--- a/src/main/resources/db/migration/V202403041730__add_metadata_column_to_magazine.sql
+++ b/src/main/resources/db/migration/V202403041730__add_metadata_column_to_magazine.sql
@@ -1,2 +1,2 @@
 ALTER TABLE `magazine`
-    ADD `metadata` JSON NULL DEFAULT NULL AFTER `content`,
+    ADD `metadata` JSON NULL DEFAULT NULL AFTER `content`;

--- a/src/test/java/com/example/codebase/controller/MagazineControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/MagazineControllerTest.java
@@ -621,6 +621,30 @@ class MagazineControllerTest {
         assertTrue(magazineResponse.getMetadata().containsKey("font"));
         assertEquals(magazineResponse.getMetadata().get("color"), "빨강으로");
         assertEquals(magazineResponse.getMetadata().get("font"), "다른 폰트");
+    }
 
+    @DisplayName("해당 사용자의 매거진 전체 조회 시")
+    @Test
+    void 해당_사용자의_매거진_전체_조회() throws Exception {
+        // given
+        Member member = createMember("testid");
+        createMagaizne(member);
+        createMagaizne(member);
+        createMagaizne(member);
+        createMagaizne(member);
+
+        // when
+        String response = mockMvc.perform(
+                        get("/api/magazines/members/{username}", member.getUsername())
+                                .param("page", "0")
+                                .param("size", "10")
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        // then
+        MagazineResponse.GetAll magazineList = objectMapper.readValue(response, MagazineResponse.GetAll.class);
+        assertEquals(magazineList.getMagazines().size(), 4);
     }
 }


### PR DESCRIPTION
- 매거진 메타데이터 필드가 추가되었습니다
  - 이제 JSON 형식으로 매거진의 메타데이터를 추가할 수 있습니다.
- 매거진 수정 API의 형식이 변경되었습니다.
  - 기존 데이터를 포함해서 업데이트 되는 수정 로직에 따라 Patch 방식이 아닌 Put 방식으로 변경되었습니다.
  - 업데이트 시 메타데이터를 수정할 수 있습니다.
- 사용자가 작성한 매거진 조회 API 가 구현되었습니다. 


연관된 티켓 : [ARTDEV-149](https://mediaxi.atlassian.net/jira/software/projects/ARTDEV/boards/1?selectedIssue=ARTDEV-149), [ARTDEV-148](https://mediaxi.atlassian.net/jira/software/projects/ARTDEV/boards/1?selectedIssue=ARTDEV-148)

[ARTDEV-149]: https://mediaxi.atlassian.net/browse/ARTDEV-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ARTDEV-148]: https://mediaxi.atlassian.net/browse/ARTDEV-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ