### PR TITLE
연관객체 조회시 추가적인 쿼리가 발생하는 문제 해결 (N+1)

### DIFF
--- a/src/main/java/com/example/codebase/domain/magazine/entity/Magazine.java
+++ b/src/main/java/com/example/codebase/domain/magazine/entity/Magazine.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Where;
 
 import java.time.LocalDateTime;
@@ -66,14 +67,17 @@ public class Magazine {
     private MagazineCategory category;
 
     @Builder.Default
+    @BatchSize(size = 25)
     @OneToMany(mappedBy = "magazine", cascade = CascadeType.ALL)
     private List<MagazineComment> magazineComments = new ArrayList<>();
 
     @Builder.Default
+    @BatchSize(size = 25)
     @OneToMany(mappedBy = "magazine", cascade = CascadeType.ALL)
     private List<MagazineLike> magazineLikes = new ArrayList<>();
 
     @Builder.Default
+    @BatchSize(size = 25)
     @OneToMany(mappedBy = "magazine", cascade = CascadeType.ALL)
     private List<MagazineMedia> magazineMedias = new ArrayList<>();
 

--- a/src/main/java/com/example/codebase/domain/magazine/entity/MagazineComment.java
+++ b/src/main/java/com/example/codebase/domain/magazine/entity/MagazineComment.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Where;
 
 import java.time.LocalDateTime;
@@ -67,6 +68,7 @@ public class MagazineComment {
     private MagazineComment parentComment;
 
     @Builder.Default
+    @BatchSize(size = 10) // TODO : 배치 사이즈를 부모 댓글 개수에 따라 조절
     @OneToMany(mappedBy = "parentComment", fetch = FetchType.LAZY)
     private List<MagazineComment> childComments = new ArrayList<>();
 

--- a/src/main/resources/application-mysql.yml
+++ b/src/main/resources/application-mysql.yml
@@ -16,6 +16,7 @@ spring:
         #        show_sql: true
         #        format_sql: true
         enable_lazy_load_no_trans: true # LAZY 로드를 default로 설정
+        default_batch_fetch_size: 30 # TODO : 상황에 맞게 조절
 
 # # Flyway 사용으로 초기화 주석
 #    defer-datasource-initialization: true


### PR DESCRIPTION
- 전역 BatchSize는 30, 데이터 크기에 따라 조절 필요
- Magazine, MagazineComment 조회하는 데이터 개수 예상하여 BatchSize 적용
  - 각 사용되는 도메인 별 데이터 개수를 추정하여 배치 사이즈를 조정할 필요가 있음
  - 하지만 현재로썬 데이터가 많이 없으므로 추후 진행