### PR TITLE
feat 메거진 팀 글쓰기 기능

### DIFF
--- a/src/main/java/com/example/codebase/annotation/CheckDuplicatedRequest.java
+++ b/src/main/java/com/example/codebase/annotation/CheckDuplicatedRequest.java
@@ -8,5 +8,7 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CheckDuplicatedRequest {
-    String target();
+    String target() default "";
+
+    int aliveMillisecondTime() default 3000;
 }

--- a/src/main/java/com/example/codebase/annotation/CheckDuplicatedRequest.java
+++ b/src/main/java/com/example/codebase/annotation/CheckDuplicatedRequest.java
@@ -1,0 +1,12 @@
+package com.example.codebase.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckDuplicatedRequest {
+    String target();
+}

--- a/src/main/java/com/example/codebase/aop/CheckDuplicatedRequestAspect.java
+++ b/src/main/java/com/example/codebase/aop/CheckDuplicatedRequestAspect.java
@@ -1,0 +1,51 @@
+package com.example.codebase.aop;
+
+import com.example.codebase.annotation.CheckDuplicatedRequest;
+import com.example.codebase.exception.DuplicatedRequestException;
+import com.example.codebase.util.RedisUtil;
+import com.example.codebase.util.SecurityUtil;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+import java.time.LocalDateTime;
+
+@Aspect
+@Component
+public class CheckDuplicatedRequestAspect {
+
+    private final RedisUtil redisUtil;
+
+    @Autowired
+    private CheckDuplicatedRequestAspect(RedisUtil redisUtil) {
+        this.redisUtil = redisUtil;
+    }
+
+    @Before("@annotation(com.example.codebase.annotation.CheckDuplicatedRequest)")
+    public void checkDuplicateRequest(JoinPoint joinPoint) {
+        CheckDuplicatedRequest checkDuplicatedRequest = getAnnotation(joinPoint);
+        String username = String.valueOf(SecurityUtil.getCurrentUsername());
+
+        if(username.isEmpty()){
+            return;
+        }
+
+        String target = checkDuplicatedRequest.target();
+
+        String uniqueKey = username + "->" + target;
+        if (redisUtil.getData(uniqueKey).isPresent()) {
+            throw new DuplicatedRequestException();
+        }
+        redisUtil.setDataAndExpire(uniqueKey, String.valueOf(LocalDateTime.now()), 3000);
+    }
+
+    private CheckDuplicatedRequest getAnnotation(JoinPoint joinPoint) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        return method.getAnnotation(CheckDuplicatedRequest.class);
+    }
+}

--- a/src/main/java/com/example/codebase/aop/CheckDuplicatedRequestAspect.java
+++ b/src/main/java/com/example/codebase/aop/CheckDuplicatedRequestAspect.java
@@ -1,7 +1,11 @@
 package com.example.codebase.aop;
 
 import com.example.codebase.annotation.CheckDuplicatedRequest;
+import com.example.codebase.annotation.LoginOnly;
+import com.example.codebase.annotation.UserAdminOnly;
+import com.example.codebase.annotation.UserOnly;
 import com.example.codebase.exception.DuplicatedRequestException;
+import com.example.codebase.exception.LoginRequiredException;
 import com.example.codebase.util.RedisUtil;
 import com.example.codebase.util.SecurityUtil;
 import org.aspectj.lang.JoinPoint;
@@ -9,6 +13,7 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.lang.reflect.Method;
@@ -16,6 +21,7 @@ import java.time.LocalDateTime;
 
 @Aspect
 @Component
+@Profile("!test")
 public class CheckDuplicatedRequestAspect {
 
     private final RedisUtil redisUtil;
@@ -27,25 +33,28 @@ public class CheckDuplicatedRequestAspect {
 
     @Before("@annotation(com.example.codebase.annotation.CheckDuplicatedRequest)")
     public void checkDuplicateRequest(JoinPoint joinPoint) {
-        CheckDuplicatedRequest checkDuplicatedRequest = getAnnotation(joinPoint);
-        String username = String.valueOf(SecurityUtil.getCurrentUsername());
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        CheckDuplicatedRequest annotation = method.getAnnotation(CheckDuplicatedRequest.class);
 
-        if(username.isEmpty()){
-            return;
-        }
+        if (!isValidAnnotation(method)) return;
 
-        String target = checkDuplicatedRequest.target();
+        String username = SecurityUtil.getCurrentUsername().orElseThrow(LoginRequiredException::new);
+
+        if (username.isEmpty()) return;
+
+        String target = annotation.target().isEmpty() ? String.valueOf(method) : annotation.target();
 
         String uniqueKey = username + "->" + target;
         if (redisUtil.getData(uniqueKey).isPresent()) {
             throw new DuplicatedRequestException();
         }
-        redisUtil.setDataAndExpire(uniqueKey, String.valueOf(LocalDateTime.now()), 3000);
+        redisUtil.setDataAndExpire(uniqueKey, String.valueOf(LocalDateTime.now()), annotation.aliveMillisecondTime());
     }
 
-    private CheckDuplicatedRequest getAnnotation(JoinPoint joinPoint) {
-        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
-        Method method = signature.getMethod();
-        return method.getAnnotation(CheckDuplicatedRequest.class);
+    private boolean isValidAnnotation(Method method) {
+        return method.isAnnotationPresent(LoginOnly.class)
+                || method.isAnnotationPresent(UserOnly.class)
+                || method.isAnnotationPresent(UserAdminOnly.class);
     }
 }

--- a/src/main/java/com/example/codebase/aop/CheckDuplicatedRequestAspect.java
+++ b/src/main/java/com/example/codebase/aop/CheckDuplicatedRequestAspect.java
@@ -27,7 +27,7 @@ public class CheckDuplicatedRequestAspect {
     private final RedisUtil redisUtil;
 
     @Autowired
-    private CheckDuplicatedRequestAspect(RedisUtil redisUtil) {
+    protected CheckDuplicatedRequestAspect(RedisUtil redisUtil) {
         this.redisUtil = redisUtil;
     }
 
@@ -39,13 +39,13 @@ public class CheckDuplicatedRequestAspect {
 
         if (!isValidAnnotation(method)) return;
 
-        String username = SecurityUtil.getCurrentUsername().orElseThrow(LoginRequiredException::new);
+        String key = SecurityUtil.getCurrentUsername().orElseThrow(LoginRequiredException::new);
 
-        if (username.isEmpty()) return;
+        if (key.isEmpty()) return;
 
         String target = annotation.target().isEmpty() ? String.valueOf(method) : annotation.target();
 
-        String uniqueKey = username + "->" + target;
+        String uniqueKey = key + "->" + target;
         if (redisUtil.getData(uniqueKey).isPresent()) {
             throw new DuplicatedRequestException();
         }

--- a/src/main/java/com/example/codebase/controller/MagazineController.java
+++ b/src/main/java/com/example/codebase/controller/MagazineController.java
@@ -65,7 +65,7 @@ public class MagazineController {
             parameters = @Parameter(name = "action", description = "member: 개인 매거진 생성, team: 팀 매거진 생성", required = true, example = "team"),
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     description = "매거진 생성자 URN", required = true, content = @io.swagger.v3.oas.annotations.media.Content(
-                    schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = FollowRequest.Create.class),
+                    schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = MagazineRequest.Create.class),
                     examples = @io.swagger.v3.oas.annotations.media.ExampleObject(value =
                             "{\"title\": \"매거진 제목\"," +
                                     "\"content\": \"매거진 내용\", " +

--- a/src/main/java/com/example/codebase/domain/magazine/dto/MagazineRequest.java
+++ b/src/main/java/com/example/codebase/domain/magazine/dto/MagazineRequest.java
@@ -1,9 +1,7 @@
 package com.example.codebase.domain.magazine.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.validator.constraints.URL;
@@ -34,6 +32,11 @@ public class MagazineRequest {
 
         @Size(max = 10, message = "최대 10개 까지 미디어 첨부 가능합니다.")
         private List<@URL(message = "올바른 URL 형식이 아닙니다.") String> mediaUrls = Collections.emptyList();
+
+        @NotBlank(message = "URN을 입력해주세요.")
+        @Pattern(regexp = "^urn:(member|team:\\w+)$", message = "올바른 URN 형식이 아닙니다.")
+        private String urn;
+
     }
 
     @Getter
@@ -53,5 +56,43 @@ public class MagazineRequest {
         private Map<String, String> metadata;
 
         private List<String> mediaUrls;
+    }
+
+    @Schema(name = "MagazineRequest.MagazineEntityUrn", description = "MagazineEntityUrn Request")
+    public enum MagazineEntityUrn {
+        MEMBER("urn:member"),
+        TEAM("urn:team");
+
+        private final String resource;
+
+        @Getter String id;
+
+        MagazineEntityUrn(String resource){
+            this.resource = resource;
+            this.id = null;
+        }
+
+        public static MagazineEntityUrn from (String urn){
+            try {
+                String[] checkSplit = urn.split(":");
+
+                if (checkSplit.length == 2) {
+                    return MagazineEntityUrn.valueOf(checkSplit[1].toUpperCase());
+                } else if (checkSplit.length == 3) {
+                    String resource = checkSplit[1];
+                    String id = checkSplit[2];
+
+                    MagazineEntityUrn magazineEntityUrn = MagazineEntityUrn.valueOf(resource.toUpperCase());
+                    magazineEntityUrn.id = id;
+                    return magazineEntityUrn;
+                }
+                else{
+                    throw new RuntimeException("유효하지 않은 EntityUrn 입니다.");
+                }
+            }
+            catch (IllegalArgumentException e){
+                throw new RuntimeException("유효하지 않은 EntityUrn 입니다.");
+            }
+        }
     }
 }

--- a/src/main/java/com/example/codebase/domain/magazine/dto/MagazineResponse.java
+++ b/src/main/java/com/example/codebase/domain/magazine/dto/MagazineResponse.java
@@ -45,6 +45,10 @@ public class MagazineResponse {
 
         private AuthorResponse author;
 
+        private String teamName;
+
+        private Long teamId;
+
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
         private LocalDateTime createdTime;
 
@@ -71,6 +75,12 @@ public class MagazineResponse {
             response.author = AuthorResponse.from(magazine.getMember());
             response.createdTime = magazine.getCreatedTime();
             response.updatedTime = magazine.getUpdatedTime();
+
+            if (magazine.getTeam() != null) {
+                response.setTeamId(magazine.getTeam().getId());
+                response.setTeamName(magazine.getTeam().getName());
+            }
+
 
             // 1차 댓글만 가져오기
             response.magazineComments = magazine.getMagazineComments().stream()

--- a/src/main/java/com/example/codebase/domain/magazine/entity/Magazine.java
+++ b/src/main/java/com/example/codebase/domain/magazine/entity/Magazine.java
@@ -2,6 +2,8 @@ package com.example.codebase.domain.magazine.entity;
 
 import com.example.codebase.domain.magazine.dto.MagazineRequest;
 import com.example.codebase.domain.member.entity.Member;
+import com.example.codebase.domain.team.entity.Team;
+import com.example.codebase.domain.team.entity.TeamUser;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -88,6 +90,10 @@ public class Magazine {
     @OneToMany(mappedBy = "magazine", cascade = CascadeType.ALL)
     private List<MagazineMedia> magazineMedias = new ArrayList<>();
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn( name = "team_id")
+    private Team team;
+
     public static Magazine toEntity(MagazineRequest.Create magazineRequest, Member member, MagazineCategory category) {
         return Magazine.builder()
                 .title(magazineRequest.getTitle())
@@ -99,6 +105,20 @@ public class Magazine {
                 .updatedTime(LocalDateTime.now())
                 .build();
     }
+
+    public static Magazine toEntity(MagazineRequest.Create magazineRequest, TeamUser teamUser, MagazineCategory category){
+        return Magazine.builder()
+                .title(magazineRequest.getTitle())
+                .content(magazineRequest.getContent())
+                .metadata(magazineRequest.getMetadata())
+                .team(teamUser.getTeam())
+                .member(teamUser.getMember())
+                .category(category)
+                .createdTime(LocalDateTime.now())
+                .updatedTime(LocalDateTime.now())
+                .build();
+    }
+
 
     public boolean isOwner(String loginUsername) {
         return member.getUsername().equals(loginUsername);

--- a/src/main/java/com/example/codebase/domain/magazine/entity/Magazine.java
+++ b/src/main/java/com/example/codebase/domain/magazine/entity/Magazine.java
@@ -90,9 +90,10 @@ public class Magazine {
     @OneToMany(mappedBy = "magazine", cascade = CascadeType.ALL)
     private List<MagazineMedia> magazineMedias = new ArrayList<>();
 
+    @Builder.Default
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn( name = "team_id")
-    private Team team;
+    @JoinColumn(name = "team_id")
+    private Team team = null;
 
     public static Magazine toEntity(MagazineRequest.Create magazineRequest, Member member, MagazineCategory category) {
         return Magazine.builder()
@@ -106,7 +107,7 @@ public class Magazine {
                 .build();
     }
 
-    public static Magazine toEntity(MagazineRequest.Create magazineRequest, TeamUser teamUser, MagazineCategory category){
+    public static Magazine toEntity(MagazineRequest.Create magazineRequest, TeamUser teamUser, MagazineCategory category) {
         return Magazine.builder()
                 .title(magazineRequest.getTitle())
                 .content(magazineRequest.getContent())
@@ -114,6 +115,19 @@ public class Magazine {
                 .team(teamUser.getTeam())
                 .member(teamUser.getMember())
                 .category(category)
+                .createdTime(LocalDateTime.now())
+                .updatedTime(LocalDateTime.now())
+                .build();
+    }
+
+    public static Magazine toEntity(MagazineRequest.Create magazineRequest, Member member, MagazineCategory category, Team team) {
+        return Magazine.builder()
+                .title(magazineRequest.getTitle())
+                .content(magazineRequest.getContent())
+                .metadata(magazineRequest.getMetadata())
+                .member(member)
+                .category(category)
+                .team(team)
                 .createdTime(LocalDateTime.now())
                 .updatedTime(LocalDateTime.now())
                 .build();

--- a/src/main/java/com/example/codebase/domain/magazine/repository/MagazineRepository.java
+++ b/src/main/java/com/example/codebase/domain/magazine/repository/MagazineRepository.java
@@ -2,6 +2,7 @@ package com.example.codebase.domain.magazine.repository;
 
 import com.example.codebase.domain.magazine.entity.Magazine;
 import com.example.codebase.domain.member.entity.Member;
+import com.example.codebase.domain.team.entity.Team;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,9 +15,11 @@ public interface MagazineRepository extends JpaRepository<Magazine, Long> {
     @Query("SELECT m FROM Magazine m WHERE m.id = :id AND m.isDeleted = false")
     Optional<Magazine> findById(Long id);
 
+    @Query("SELECT m FROM Magazine m WHERE m.member = :member AND m.team is null")
     Page<Magazine> findByMember(Member member, PageRequest pageRequest);
 
     @Query("SELECT m FROM Magazine m LEFT JOIN Follow f ON (f.follower= :member) WHERE f.followingMember = m.member")
     Page<Magazine> findByMemberToFollowing(Member member, PageRequest pageRequest);
 
+    Page<Magazine> findByTeam(Team team, PageRequest pageRequest);
 }

--- a/src/main/java/com/example/codebase/domain/magazine/service/MagazineService.java
+++ b/src/main/java/com/example/codebase/domain/magazine/service/MagazineService.java
@@ -13,6 +13,7 @@ import com.example.codebase.domain.magazine.repository.MagazineRepository;
 import com.example.codebase.domain.member.entity.Member;
 import com.example.codebase.domain.team.entity.Team;
 import com.example.codebase.domain.team.entity.TeamUser;
+import com.example.codebase.domain.team.repository.TeamRepository;
 import com.example.codebase.exception.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -20,6 +21,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 @Service
@@ -41,18 +43,9 @@ public class MagazineService {
     }
 
     @Transactional
-    public MagazineResponse.Get createMemberMagazine(MagazineRequest.Create magazineRequest, Member member, MagazineCategory category) {
-        Magazine newMagazine = Magazine.toEntity(magazineRequest, member, category);
-        magazineRepository.save(newMagazine);
+    public MagazineResponse.Get createMagazine(MagazineRequest.Create magazineRequest, Member member, MagazineCategory category, @Nullable Team team) {
+        Magazine newMagazine = Magazine.toEntity(magazineRequest, member, category, team);
 
-        List<MagazineMedia> magazineMedias = MagazineMedia.toList(magazineRequest.getMediaUrls(), newMagazine);
-        magazineMediaRepository.saveAll(magazineMedias);
-        return MagazineResponse.Get.from(newMagazine);
-    }
-
-    @Transactional
-    public MagazineResponse.Get createTeamMagazine(MagazineRequest.Create magazineRequest, TeamUser teamMember, MagazineCategory category) {
-        Magazine newMagazine = Magazine.toEntity(magazineRequest, teamMember, category);
         magazineRepository.save(newMagazine);
 
         List<MagazineMedia> magazineMedias = MagazineMedia.toList(magazineRequest.getMediaUrls(), newMagazine);
@@ -179,11 +172,6 @@ public class MagazineService {
 
     public MagazineResponse.GetAll getMemberMagazines(Member member, PageRequest pageRequest) {
         Page<Magazine> magazines = magazineRepository.findByMember(member, pageRequest);
-        return MagazineResponse.GetAll.from(magazines);
-    }
-
-    public MagazineResponse.GetAll getTeamMagazines(Team team, PageRequest pageRequest) {
-        Page<Magazine> magazines = magazineRepository.findByTeam(team, pageRequest);
         return MagazineResponse.GetAll.from(magazines);
     }
 

--- a/src/main/java/com/example/codebase/domain/team/entity/Team.java
+++ b/src/main/java/com/example/codebase/domain/team/entity/Team.java
@@ -1,5 +1,6 @@
 package com.example.codebase.domain.team.entity;
 
+import com.example.codebase.domain.magazine.entity.Magazine;
 import com.example.codebase.domain.team.dto.TeamRequest;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/example/codebase/domain/team/service/TeamService.java
+++ b/src/main/java/com/example/codebase/domain/team/service/TeamService.java
@@ -43,6 +43,11 @@ public class TeamService {
         return TeamResponse.Get.from(team);
     }
 
+    @Transactional(readOnly = true)
+    public Team getEntity(String teamName) {
+        return teamRepository.findByName(teamName).orElseThrow(() -> new NotFoundException("팀이 존재하지 않습니다."));
+    }
+
     public TeamResponse.Get updateTeam(TeamRequest.Update request, TeamUser teamUser) {
         Team team = teamUser.getTeam();
 

--- a/src/main/resources/db/migration/V202403051158__application.sql
+++ b/src/main/resources/db/migration/V202403051158__application.sql
@@ -1,0 +1,8 @@
+# 매거진 테이블에 teami� coulum 추가
+# 작성자 : gimdonghyeon (haroya01@naver.com)
+# 작성 날짜  : 2024-04-04
+# 현재 버전  : V202403051158 (이전 버전 : V202403051157__application.sql)
+
+ALTER TABLE `magazine`
+    ADD `team_id` BIGINT NULL,
+    ADD CONSTRAINT `fk_magazine_team_id` FOREIGN KEY (`team_id`) REFERENCES `team` (`team_id`);

--- a/src/test/java/com/example/codebase/aop/CheckDuplicatedRequestAspectMock.java
+++ b/src/test/java/com/example/codebase/aop/CheckDuplicatedRequestAspectMock.java
@@ -1,0 +1,67 @@
+package com.example.codebase.aop;
+
+import com.example.codebase.annotation.CheckDuplicatedRequest;
+import com.example.codebase.annotation.LoginOnly;
+import com.example.codebase.annotation.UserAdminOnly;
+import com.example.codebase.annotation.UserOnly;
+import com.example.codebase.exception.DuplicatedRequestException;
+import com.example.codebase.exception.LoginRequiredException;
+import com.example.codebase.util.RedisUtil;
+import com.example.codebase.util.SecurityUtil;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+import java.time.LocalDateTime;
+
+@Profile("test")
+@Aspect
+@Component
+public class CheckDuplicatedRequestAspectMock {
+
+    private final RedisUtil redisUtil;
+
+    @Autowired
+    private CheckDuplicatedRequestAspectMock(RedisUtil redisUtil) {
+        this.redisUtil = redisUtil;
+    }
+
+    @Before("@annotation(com.example.codebase.annotation.CheckDuplicatedRequest)")
+    public void checkDuplicateRequest(JoinPoint joinPoint) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        CheckDuplicatedRequest annotation = method.getAnnotation(CheckDuplicatedRequest.class);
+
+        if (!isValidAnnotation(method)) return;
+
+        String username = SecurityUtil.getCurrentUsername().orElseThrow(LoginRequiredException::new);
+
+        // 테스트 시 테스트 유저는 제외
+        if (username.isEmpty() || username.equals("testid")) {
+            return;
+        }
+
+        String target = annotation.target().isEmpty() ? String.valueOf(method) : annotation.target();
+
+        String uniqueKey = username + "->" + target;
+        if (redisUtil.getData(uniqueKey).isPresent()) {
+            throw new DuplicatedRequestException();
+        }
+        redisUtil.setDataAndExpire(uniqueKey, String.valueOf(LocalDateTime.now()), annotation.aliveMillisecondTime());
+    }
+
+    private boolean isValidAnnotation(Method method) {
+        return method.isAnnotationPresent(LoginOnly.class)
+                || method.isAnnotationPresent(UserOnly.class)
+                || method.isAnnotationPresent(UserAdminOnly.class);
+    }
+
+    private boolean isLoginUser() {
+        return SecurityUtil.getCurrentUsername().isEmpty();
+    }
+}

--- a/src/test/java/com/example/codebase/aop/CheckDuplicatedRequestAspectMock.java
+++ b/src/test/java/com/example/codebase/aop/CheckDuplicatedRequestAspectMock.java
@@ -1,67 +1,29 @@
 package com.example.codebase.aop;
 
-import com.example.codebase.annotation.CheckDuplicatedRequest;
-import com.example.codebase.annotation.LoginOnly;
-import com.example.codebase.annotation.UserAdminOnly;
-import com.example.codebase.annotation.UserOnly;
-import com.example.codebase.exception.DuplicatedRequestException;
+
 import com.example.codebase.exception.LoginRequiredException;
 import com.example.codebase.util.RedisUtil;
 import com.example.codebase.util.SecurityUtil;
 import org.aspectj.lang.JoinPoint;
-import org.aspectj.lang.annotation.Aspect;
-import org.aspectj.lang.annotation.Before;
-import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
-import java.lang.reflect.Method;
-import java.time.LocalDateTime;
 
-@Profile("test")
-@Aspect
 @Component
-public class CheckDuplicatedRequestAspectMock {
-
-    private final RedisUtil redisUtil;
+@Profile("test")
+public class CheckDuplicatedRequestAspectMock extends CheckDuplicatedRequestAspect {
 
     @Autowired
-    private CheckDuplicatedRequestAspectMock(RedisUtil redisUtil) {
-        this.redisUtil = redisUtil;
+    public CheckDuplicatedRequestAspectMock(RedisUtil redisUtil) {
+        super(redisUtil);
     }
 
-    @Before("@annotation(com.example.codebase.annotation.CheckDuplicatedRequest)")
+    @Override
     public void checkDuplicateRequest(JoinPoint joinPoint) {
-        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
-        Method method = signature.getMethod();
-        CheckDuplicatedRequest annotation = method.getAnnotation(CheckDuplicatedRequest.class);
-
-        if (!isValidAnnotation(method)) return;
-
         String username = SecurityUtil.getCurrentUsername().orElseThrow(LoginRequiredException::new);
-
-        // 테스트 시 테스트 유저는 제외
-        if (username.isEmpty() || username.equals("testid")) {
-            return;
+        if (!username.equals("testid")) {
+            super.checkDuplicateRequest(joinPoint);
         }
-
-        String target = annotation.target().isEmpty() ? String.valueOf(method) : annotation.target();
-
-        String uniqueKey = username + "->" + target;
-        if (redisUtil.getData(uniqueKey).isPresent()) {
-            throw new DuplicatedRequestException();
-        }
-        redisUtil.setDataAndExpire(uniqueKey, String.valueOf(LocalDateTime.now()), annotation.aliveMillisecondTime());
-    }
-
-    private boolean isValidAnnotation(Method method) {
-        return method.isAnnotationPresent(LoginOnly.class)
-                || method.isAnnotationPresent(UserOnly.class)
-                || method.isAnnotationPresent(UserAdminOnly.class);
-    }
-
-    private boolean isLoginUser() {
-        return SecurityUtil.getCurrentUsername().isEmpty();
     }
 }

--- a/src/test/java/com/example/codebase/controller/CurationControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/CurationControllerTest.java
@@ -172,7 +172,7 @@ public class CurationControllerTest {
         magazineRequest.setContent("내용");
         magazineRequest.setCategorySlug(category.getSlug());
 
-        return magazineService.createMemberMagazine(magazineRequest, member, category);
+        return magazineService.createMagazine(magazineRequest, member, category, null);
     }
 
     MagazineResponse.Get createMagazine(Member member, MagazineCategory category) {
@@ -181,7 +181,7 @@ public class CurationControllerTest {
         magazineRequest.setContent("내용");
         magazineRequest.setCategorySlug(category.getSlug());
 
-        return magazineService.createMemberMagazine(magazineRequest, member, category);
+        return magazineService.createMagazine(magazineRequest, member, category, null);
     }
 
 

--- a/src/test/java/com/example/codebase/controller/CurationControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/CurationControllerTest.java
@@ -172,7 +172,7 @@ public class CurationControllerTest {
         magazineRequest.setContent("내용");
         magazineRequest.setCategorySlug(category.getSlug());
 
-        return magazineService.create(magazineRequest, member, category);
+        return magazineService.createMemberMagazine(magazineRequest, member, category);
     }
 
     MagazineResponse.Get createMagazine(Member member, MagazineCategory category) {
@@ -181,7 +181,7 @@ public class CurationControllerTest {
         magazineRequest.setContent("내용");
         magazineRequest.setCategorySlug(category.getSlug());
 
-        return magazineService.create(magazineRequest, member, category);
+        return magazineService.createMemberMagazine(magazineRequest, member, category);
     }
 
 

--- a/src/test/java/com/example/codebase/controller/MagazineCategoryControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/MagazineCategoryControllerTest.java
@@ -101,7 +101,7 @@ class MagazineCategoryControllerTest {
                 "https://cdn.artscope.kr/local/2.jpg"
         ));
 
-        return magazineService.create(magazineRequest, member, category);
+        return magazineService.createMemberMagazine(magazineRequest, member, category);
     }
 
     public Member createMember(String username) {

--- a/src/test/java/com/example/codebase/controller/MagazineCategoryControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/MagazineCategoryControllerTest.java
@@ -101,7 +101,7 @@ class MagazineCategoryControllerTest {
                 "https://cdn.artscope.kr/local/2.jpg"
         ));
 
-        return magazineService.createMemberMagazine(magazineRequest, member, category);
+        return magazineService.createMagazine(magazineRequest, member, category, null);
     }
 
     public Member createMember(String username) {
@@ -268,7 +268,7 @@ class MagazineCategoryControllerTest {
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
         // then
-        MagazineCategoryResponse.Get updatedCategory =objectMapper.readValue(response, MagazineCategoryResponse.Get.class);
+        MagazineCategoryResponse.Get updatedCategory = objectMapper.readValue(response, MagazineCategoryResponse.Get.class);
         assertEquals(updateRequest.getName(), updatedCategory.getName());
         assertEquals(updateRequest.getSlug(), updatedCategory.getSlug());
         assertEquals(updateRequest.getParentId(), updatedCategory.getParentCategory().getId());
@@ -393,7 +393,7 @@ class MagazineCategoryControllerTest {
         // given
         MagazineCategory parentCategory = createCategoryAndLoad();
 
-        createMagaizne(createMember("admin"),parentCategory);
+        createMagaizne(createMember("admin"), parentCategory);
 
         // when
         mockMvc.perform(

--- a/src/test/java/com/example/codebase/controller/MagazineControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/MagazineControllerTest.java
@@ -112,7 +112,7 @@ class MagazineControllerTest {
                 "https://cdn.artscope.kr/local/2.jpg"
         ));
 
-        return magazineService.createMemberMagazine(magazineRequest, member, category);
+        return magazineService.createMagazine(magazineRequest, member, category, null);
     }
 
     public MagazineResponse.Get createMagaizne(TeamUser teamUser) {
@@ -131,7 +131,7 @@ class MagazineControllerTest {
                 "https://cdn.artscope.kr/local/2.jpg"
         ));
 
-        return magazineService.createTeamMagazine(magazineRequest, teamUser, category);
+        return magazineService.createMagazine(magazineRequest, teamUser.getMember(), category, teamUser.getTeam());
     }
 
     public MagazineCategory createCategory() {
@@ -187,12 +187,12 @@ class MagazineControllerTest {
     }
 
 
-    @WithMockCustomUser(username = "testid1", role = "USER")
+    @WithMockCustomUser(username = "testid", role = "USER")
     @DisplayName("매거진 생성이 된다.")
     @Test
     void 매거진_생성() throws Exception {
         // given
-        createMember("testid1");
+        createMember("testid");
         MagazineCategoryRequest.Create request = new MagazineCategoryRequest.Create("글", "slug", null);
         MagazineCategoryResponse.Create category = magazineCategoryService.createCategory(request);
 
@@ -200,7 +200,6 @@ class MagazineControllerTest {
         magazineRequest.setTitle("제목");
         magazineRequest.setContent("내용");
         magazineRequest.setCategorySlug(category.getSlug());
-        magazineRequest.setUrn("urn:member");
 
         // when
         String response = mockMvc.perform(
@@ -220,17 +219,16 @@ class MagazineControllerTest {
         assertEquals(magazine.getCategoryId(), category.getId());
     }
 
-    @WithMockCustomUser(username = "testid2", role = "USER")
+    @WithMockCustomUser(username = "testid", role = "USER")
     @DisplayName("매거진 생성시 카테고리가 없으면 400.")
     @Test
     void 매거진_생성_에러() throws Exception {
         // given
-        createMember("testid2");
+        createMember("testid");
         MagazineRequest.Create magazineRequest = new MagazineRequest.Create();
         magazineRequest.setTitle("제목");
         magazineRequest.setContent("내용");
         magazineRequest.setCategorySlug("slug");
-        magazineRequest.setUrn("urn:member");
 
         // when
         String content = mockMvc.perform(
@@ -307,12 +305,12 @@ class MagazineControllerTest {
         assertTrue(content.contains("해당 매거진이 존재하지 않습니다."));
     }
 
-    @WithMockCustomUser(username = "testid3", role = "USER")
+    @WithMockCustomUser(username = "testid", role = "USER")
     @DisplayName("매거진 수정이 된다.")
     @Test
     void 매거진_수정() throws Exception {
         // given
-        Member author = createMember("testid3");
+        Member author = createMember("testid");
         MagazineResponse.Get magazine = createMagaizne(author);
 
         MagazineRequest.Update magazineRequest = new MagazineRequest.Update();
@@ -338,7 +336,7 @@ class MagazineControllerTest {
         assertEquals(magazineRequest.getCategorySlug(), magazineResponse.getCategorySlug());
     }
 
-    @WithMockCustomUser(username = "testid4", role = "USER")
+    @WithMockCustomUser(username = "testid", role = "USER")
     @DisplayName("매거진 수정시 없는 매거진이면 404.")
     @Test
     void 매거진_수정_에러() throws Exception {
@@ -363,12 +361,12 @@ class MagazineControllerTest {
         assertTrue(content.contains("해당 매거진이 존재하지 않습니다."));
     }
 
-    @WithMockCustomUser(username = "testid5", role = "USER")
+    @WithMockCustomUser(username = "testid", role = "USER")
     @DisplayName("매거진 삭제가 된다.")
     @Test
     void 매거진_삭제() throws Exception {
         // given
-        Member author = createMember("testid5");
+        Member author = createMember("testid");
         MagazineResponse.Get magazine = createMagaizne(author);
 
         // when
@@ -386,7 +384,7 @@ class MagazineControllerTest {
                 .andExpect(status().isNotFound());
     }
 
-    @WithMockCustomUser(username = "testid6", role = "USER")
+    @WithMockCustomUser(username = "testid", role = "USER")
     @DisplayName("매거진 삭제시 없는 매거진이면 404.")
     @Test
     void 매거진_삭제_에러() throws Exception {
@@ -534,12 +532,12 @@ class MagazineControllerTest {
                 .andExpect(status().isNotFound());
     }
 
-    @WithMockCustomUser(username = "testid7", role = "USER")
+    @WithMockCustomUser(username = "testid", role = "USER")
     @DisplayName("매거진 생성 시 미디어 첨부가 된다.")
     @Test
     void 매거진_미디어_생성() throws Exception {
         // given
-        createMember("testid7");
+        createMember("testid");
         MagazineCategoryRequest.Create request = new MagazineCategoryRequest.Create("글", "slug", null);
         MagazineCategoryResponse.Create category = magazineCategoryService.createCategory(request);
 
@@ -551,7 +549,6 @@ class MagazineControllerTest {
                 "https://cdn.artscope.kr/local/1.jpg",
                 "https://cdn.artscope.kr/local/2.jpg"
         ));
-        magazineRequest.setUrn("urn:member");
 
         // when
         String response = mockMvc.perform(
@@ -571,12 +568,12 @@ class MagazineControllerTest {
         assertEquals(magazine.getMediaUrls().size(), 2);
     }
 
-    @WithMockCustomUser(username = "testid8", role = "USER")
+    @WithMockCustomUser(username = "testid", role = "USER")
     @DisplayName("매거진 생성 시 잘못된 미디어 URL이면 400.")
     @Test
     void 매거진_미디어_잘못된_생성() throws Exception {
         // given
-        createMember("testid8");
+        createMember("testid");
         MagazineCategoryRequest.Create request = new MagazineCategoryRequest.Create("글", "slug", null);
         MagazineCategoryResponse.Create category = magazineCategoryService.createCategory(request);
 
@@ -600,12 +597,12 @@ class MagazineControllerTest {
                 .andExpect(status().isBadRequest());
     }
 
-    @WithMockCustomUser(username = "testid9", role = "USER")
+    @WithMockCustomUser(username = "testid", role = "USER")
     @DisplayName("매거진 생성 시 미디어 최대 개수 이상 첨부 시 400.")
     @Test
     void 매거진_미디어_잘못된_생성2() throws Exception {
         // given
-        createMember("testid9");
+        createMember("testid");
         MagazineCategoryRequest.Create request = new MagazineCategoryRequest.Create("글", "slug", null);
         MagazineCategoryResponse.Create category = magazineCategoryService.createCategory(request);
 
@@ -638,12 +635,12 @@ class MagazineControllerTest {
                 .andExpect(status().isBadRequest());
     }
 
-    @WithMockCustomUser(username = "testid10", role = "USER")
+    @WithMockCustomUser(username = "testid", role = "USER")
     @DisplayName("매거진 생성 시 메타데이터를 첨부한다.")
     @Test
     void 매거진_메타데이터_생성() throws Exception {
         // given
-        createMember("testid10");
+        createMember("testid");
         MagazineCategoryRequest.Create request = new MagazineCategoryRequest.Create("글", "slug", null);
         MagazineCategoryResponse.Create category = magazineCategoryService.createCategory(request);
 
@@ -655,7 +652,6 @@ class MagazineControllerTest {
                 "color", "blue",
                 "font", "godic"
         ));
-        magazineRequest.setUrn("urn:member");
 
         // when
         mockMvc.perform(
@@ -705,7 +701,7 @@ class MagazineControllerTest {
         assertEquals(magazineResponse.getMetadata().get("font"), "다른 폰트");
     }
 
-    @DisplayName("해당 사용자의 매거진 전체 조회 시")
+    @DisplayName("매거진 전체 조회 시")
     @Test
     void 해당_사용자의_매거진_전체_조회() throws Exception {
         // given
@@ -718,8 +714,6 @@ class MagazineControllerTest {
         // when
         String response = mockMvc.perform(
                         get("/api/magazines", member.getUsername())
-                                .param("action", "member")
-                                .param("name", member.getUsername())
                                 .param("page", "0")
                                 .param("size", "10")
                 )
@@ -764,41 +758,13 @@ class MagazineControllerTest {
         assertEquals(magazineList.getMagazines().size(), 3);
     }
 
-    @DisplayName("팀 매거진 전체 조회 시")
-    @Test
-    void 해당_팀_매거진_전체_조회() throws Exception {
-        // given
-        Member member = createMember("testid");
-        TeamResponse.Get team = createTeam(member, "팀이름");
-        TeamUser teamUser = teamUserService.findByTeamIdAndUsername(team.getId(), member.getUsername());
-
-        createMagaizne(teamUser);
-        createMagaizne(teamUser);
-        createMagaizne(teamUser);
-
-        // when
-        String response = mockMvc.perform(
-                        get("/api/magazines", member.getUsername())
-                                .param("action", "team")
-                                .param("name", teamUser.getTeam().getName())
-                                .param("page", "0")
-                                .param("size", "10")
-                )
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
-
-        // then
-        MagazineResponse.GetAll magazineList = objectMapper.readValue(response, MagazineResponse.GetAll.class);
-        assertEquals(magazineList.getMagazines().size(), 3);
-    }
-
-    @WithMockCustomUser(username = "testid11", role = "USER")
+    @WithMockCustomUser(username = "testid", role = "USER")
     @DisplayName("매거진 생성 시 잘못된 urn 형식으로 요청시 실패")
     @Test
     void 매거진_생성_urn_문제_실패() throws Exception {
         // given
-        createMember("testid10");
+        createMember("admin");
+        Member loginMember = createMember("testid");
         MagazineCategoryRequest.Create request = new MagazineCategoryRequest.Create("글", "slug", null);
         MagazineCategoryResponse.Create category = magazineCategoryService.createCategory(request);
 
@@ -810,10 +776,10 @@ class MagazineControllerTest {
                 "color", "blue",
                 "font", "godic"
         ));
-        magazineRequest.setUrn("urn:member:");
 
-        // when1 urn:member:
-        String response1 =mockMvc.perform(
+        // when1 urn에 urn:이상한값:id
+        magazineRequest.setUrn("urn:이상한값:1");
+        String response1 = mockMvc.perform(
                         post("/api/magazines")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(magazineRequest))
@@ -823,8 +789,9 @@ class MagazineControllerTest {
 
         assertTrue(response1.contains("올바른 URN 형식이 아닙니다."));
 
-        // when2 urn:member:member
-    magazineRequest.setUrn("urn:member:member");
+        // when2 urn:member urn을 완성하지 않았을 경우
+        createTeam(loginMember, "name");
+        magazineRequest.setUrn("urn:member");
         String response2 = mockMvc.perform(
                         post("/api/magazines")
                                 .contentType(MediaType.APPLICATION_JSON)
@@ -833,28 +800,46 @@ class MagazineControllerTest {
                 .andDo(print())
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
-        assertTrue(response1.contains("올바른 URN 형식이 아닙니다."));
+        assertTrue(response2.contains("올바른 URN 형식이 아닙니다."));
+    }
 
-        //when3 urn:asdf
-        magazineRequest.setUrn("urn:member:asdf");
+    @WithMockCustomUser(username = "testid", role = "USER")
+    @DisplayName("매거진 생성시 요청한 유저와 urn 유저정보가 일치 하지 않을경우")
+    @Test
+    void 매거진_생성시_요청한_유저와_urn_유저정보가_일치_하지_않을경우() throws Exception {
+        // given
+        createMember("testid");
+        createMember("notMe");
+        MagazineCategoryRequest.Create request = new MagazineCategoryRequest.Create("글", "slug", null);
+        MagazineCategoryResponse.Create category = magazineCategoryService.createCategory(request);
 
-        String response3 = mockMvc.perform(
+        MagazineRequest.Create magazineRequest = new MagazineRequest.Create();
+        magazineRequest.setTitle("제목");
+        magazineRequest.setContent("내용");
+        magazineRequest.setCategorySlug(category.getSlug());
+        magazineRequest.setUrn("urn:member:notMe");
+
+        // when
+        String response = mockMvc.perform(
                         post("/api/magazines")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(magazineRequest))
                 )
                 .andDo(print())
+                .andExpect(status().isBadRequest())
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
-        assertTrue(response1.contains("올바른 URN 형식이 아닙니다."));
+
+        //then
+        assertTrue(response.contains("요청한 urn과 로그인한 유저의 정보가 다릅니다."));
     }
 
-    @WithMockCustomUser(username = "testid12", role = "USER")
+    @WithMockCustomUser(username = "testid", role = "USER")
     @DisplayName("팀 매거진 생성시")
     @Test
     void 팀_매거진_생성() throws Exception {
         // given
-        Member member = createMember("testid12");
+        Member member = createMember("testid");
         TeamResponse.Get team = createTeam(member, "팀이름");
         TeamUser teamUser = teamUserService.findByTeamIdAndUsername(team.getId(), member.getUsername());
 
@@ -889,7 +874,7 @@ class MagazineControllerTest {
         assertEquals(magazine.getCategoryId(), category.getId());
     }
 
-    @WithMockCustomUser(username = "testid13", role = "USER")
+    @WithMockCustomUser(username = "testid", role = "USER")
     @DisplayName("팀 매거진 생성시 팀에 속해있지 않은경우 실패")
     @Test
     void 팀_매거진_생성시_해당_팀_유저가_아닌경우_실패() throws Exception {
@@ -898,7 +883,7 @@ class MagazineControllerTest {
         TeamResponse.Get team = createTeam(member, "팀이름");
         TeamUser teamUser = teamUserService.findByTeamIdAndUsername(team.getId(), member.getUsername());
 
-        createMember("testid13");
+        createMember("testid");
         MagazineCategoryRequest.Create request = new MagazineCategoryRequest.Create("글", "slug", null);
         MagazineCategoryResponse.Create category = magazineCategoryService.createCategory(request);
 
@@ -923,12 +908,46 @@ class MagazineControllerTest {
                 .andExpect(result -> assertEquals("해당 팀에 속해있지 않습니다.", result.getResolvedException().getMessage()));
     }
 
-    @WithMockCustomUser(username = "testid14", role = "USER")
+    @WithMockCustomUser(username = "testid", role = "USER")
+    @DisplayName("팀 매거진 생성시 urn에 string을 기입 할 경우 실패")
+    @Test
+    void 팀_매거진_생성시_urn에_string을_기입_할_경우_실패() throws Exception {
+        // given
+        Member member = createMember("admin");
+        TeamResponse.Get team = createTeam(member, "팀이름");
+        TeamUser teamUser = teamUserService.findByTeamIdAndUsername(team.getId(), member.getUsername());
+
+        createMember("testid");
+        MagazineCategoryRequest.Create request = new MagazineCategoryRequest.Create("글", "slug", null);
+        MagazineCategoryResponse.Create category = magazineCategoryService.createCategory(request);
+
+        MagazineRequest.Create magazineRequest = new MagazineRequest.Create();
+        magazineRequest.setTitle("제목");
+        magazineRequest.setContent("내용");
+        magazineRequest.setCategorySlug(category.getSlug());
+        magazineRequest.setMetadata(Map.of(
+                "color", "blue",
+                "font", "godic"
+        ));
+        magazineRequest.setUrn("urn:team:" + team.getName());
+
+        // when
+        mockMvc.perform(
+                        post("/api/magazines")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(magazineRequest))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(result -> assertEquals("Team URN의 ID는 숫자여야 합니다.", result.getResolvedException().getMessage()));
+    }
+
+    @WithMockCustomUser(username = "testid", role = "USER")
     @DisplayName("팀 매거진 생성시 해당팀이 존재하지 않을 경우 실패")
     @Test
     void 팀_매거진_생성시_해당팀이_존재하지_않을_경우_실패() throws Exception {
         // given
-        createMember("testid14");
+        createMember("testid");
         MagazineCategoryRequest.Create request = new MagazineCategoryRequest.Create("글", "slug", null);
         MagazineCategoryResponse.Create category = magazineCategoryService.createCategory(request);
 
@@ -953,38 +972,51 @@ class MagazineControllerTest {
                 .andExpect(result -> assertEquals("해당 팀이 존재하지 않습니다.", result.getResolvedException().getMessage()));
     }
 
-    @WithMockCustomUser(username = "testid15", role = "USER")
+    @WithMockCustomUser(username = "admin", role = "USER")
     @DisplayName("매거진 생성 api를 연속으로 호출할 시 실패 ")
     @Test
     void 매거진_생성_api를_연속으로_호출할_시_실패() throws Exception {
         // given
-        createMember("testid15");
-        MagazineCategoryRequest.Create request = new MagazineCategoryRequest.Create("글", "slug", null);
-        MagazineCategoryResponse.Create category = magazineCategoryService.createCategory(request);
+        createMember("admin");
+        MagazineCategoryRequest.Create request1 = new MagazineCategoryRequest.Create("글1", "slug1", null);
+        MagazineCategoryResponse.Create category1 = magazineCategoryService.createCategory(request1);
 
-        MagazineRequest.Create magazineRequest = new MagazineRequest.Create();
-        magazineRequest.setTitle("제목");
-        magazineRequest.setContent("내용");
-        magazineRequest.setCategorySlug(category.getSlug());
-        magazineRequest.setMetadata(Map.of(
+        MagazineRequest.Create magazineRequest1 = new MagazineRequest.Create();
+        magazineRequest1.setTitle("제목");
+        magazineRequest1.setContent("내용");
+        magazineRequest1.setCategorySlug(category1.getSlug());
+        magazineRequest1.setMetadata(Map.of(
                 "color", "blue",
                 "font", "godic"
         ));
-        magazineRequest.setUrn("urn:member");
 
+        MagazineCategoryRequest.Create request2 = new MagazineCategoryRequest.Create("글2", "slug2", category1.getId());
+        MagazineCategoryResponse.Create category2 = magazineCategoryService.createCategory(request2);
+
+        MagazineRequest.Create magazineRequest2 = new MagazineRequest.Create();
+        magazineRequest2.setTitle("제목");
+        magazineRequest2.setContent("내용");
+        magazineRequest2.setCategorySlug(category2.getSlug());
+        magazineRequest2.setMetadata(Map.of(
+                "color", "blue",
+                "font", "godic"
+        ));
+
+        //then
+        // 1차 요청
         mockMvc.perform(
                         post("/api/magazines")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(magazineRequest))
+                                .content(objectMapper.writeValueAsString(magazineRequest1))
                 )
                 .andDo(print())
                 .andExpect(status().isCreated());
 
-        // when
+        // 2차 요청
         String response = mockMvc.perform(
                         post("/api/magazines")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(magazineRequest))
+                                .content(objectMapper.writeValueAsString(magazineRequest2))
                 )
                 .andDo(print())
                 .andExpect(status().isBadRequest())


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간단하게 설명해주세요.
1. 매거진 생성시 urn을 통하여 분기하여, 팀 매거진 또는 개인 매거진을 생성할 수 있도록 변경했습니다.
@PostMapping api/magazines
2. 매거진 조회시 쿼리 파라미터를 사용해 매거진 전체 조회, 개인 조회를 통합하고 팀도 조회할 수 있도록 추가했습니다.
@GetMapping api/magazines
3. 매거진이 동시에 두번 작성되는 것을 방지하는 코드를 작성했습니다.
-> 본래 follow와 같이 서비스 코드에서 방지 로직을 작성할려고 헀지만, 
```java
createMagazine(member)
createMagazine(member)
createMagazine(member)
```
이럴경우 테스트 시 항상 해당 중복된 요청에 걸리는 문제가 발생해서 어떻게 해결할지 고민을 했습니다.

-> 해당 요청에 대한 중복 검증은 서비스 보단 컨트롤러에 위치하는게 맞는것 같아서 aop를 활용하여 bean으로 등록한뒤. @CheckDuplicatedRequest을 컨트롤러 단에 위치 시켜서 해결했습니다.

~~기존코드~~
```java
 private void checkDuplicatedRequest(MagazineRequest.Create magazineRequest, String username) {
        String uniqueKey = username + "->" + magazineRequest.getTitle();
       if (redisUtil.getData(uniqueKey).isPresent()) {
           throw new DuplicatedRequestException();
       }
       redisUtil.setDataAndExpire(uniqueKey, String.valueOf(LocalDateTime.now()), 3000);
   }
```

## 🦾 연관된 이슈
[jirra이슈](https://mediaxi.atlassian.net/jira/software/projects/ART/boards/1?selectedIssue=ART-175)

## 💬리뷰 요구사항
1. Restful하게 api가 설계 되었는지 매거진 생성, 매거진 조회 api에 대한 리뷰가 필요합니다.
2. 작업내용 3번의 동시에 작성되는걸 방지하는 로직을 aop를 활용하여 추가했는데, 해당 로직에 대해 리뷰가 필요합니다.
3. 작업내용 3번의 @CheckDuplicatedRequest을 활용하여 컨트롤러단으로 해당 요청 검증을 옮긴뒤에 서비스 코드에서 발생하던 테스트시 중복 요청 검증은 해결했지만, 여전히 통합테스트 중에 중복 문제가 발생했습니다. 

```java
@WithMockCustomUser(username = "testid13", role = "USER")
```
그래서 위의 문제를 해결하고자 현재 코드와 같이 일일히 직접 다른 유저가 하는 요청으로 만들어 해당 문제를 피하고 있습니다. 더 좋은 개선방안이 궁금합니다.
