### PR TITLE
[PR] 좋아요한 매거진 표시 기능

### DIFF
--- a/src/main/java/com/example/codebase/domain/magazine/dto/MagazineResponse.java
+++ b/src/main/java/com/example/codebase/domain/magazine/dto/MagazineResponse.java
@@ -3,6 +3,7 @@ package com.example.codebase.domain.magazine.dto;
 import com.example.codebase.controller.dto.PageInfo;
 import com.example.codebase.domain.magazine.entity.Magazine;
 import com.example.codebase.domain.magazine.entity.MagazineMedia;
+import com.example.codebase.domain.magazine.entity.MagazineWithIsLiked;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -45,6 +46,8 @@ public class MagazineResponse {
 
         private AuthorResponse author;
 
+        private Boolean isLiked = false;
+
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
         private LocalDateTime createdTime;
 
@@ -79,6 +82,12 @@ public class MagazineResponse {
                     .map(MagazineCommentRepsonse.Get::from) // 1차 댓글을 DTO로 변환 (이때 자식 댓글도 변환)
                     .toList();
 
+            return response;
+        }
+
+        public static Get from(MagazineWithIsLiked magazineWithIsLiked) {
+            Get response = from(magazineWithIsLiked.getMagazine());
+            response.isLiked = magazineWithIsLiked.getIsLiked();
             return response;
         }
 
@@ -118,5 +127,16 @@ public class MagazineResponse {
             response.pageInfo = PageInfo.from(magazines);
             return response;
         }
+
+        public static GetAll withLike(Page<MagazineWithIsLiked> magazines) {
+            GetAll response = new GetAll();
+
+            response.magazines = magazines.stream()
+                    .map(Get::from)
+                    .toList();
+            response.pageInfo = PageInfo.from(magazines);
+            return response;
+        }
+
     }
 }

--- a/src/main/java/com/example/codebase/domain/magazine/entity/MagazineWithIsLiked.java
+++ b/src/main/java/com/example/codebase/domain/magazine/entity/MagazineWithIsLiked.java
@@ -1,0 +1,8 @@
+package com.example.codebase.domain.magazine.entity;
+
+public interface MagazineWithIsLiked {
+
+    Magazine getMagazine();
+
+    Boolean getIsLiked();
+}

--- a/src/main/java/com/example/codebase/domain/magazine/repository/MagazineRepository.java
+++ b/src/main/java/com/example/codebase/domain/magazine/repository/MagazineRepository.java
@@ -1,6 +1,7 @@
 package com.example.codebase.domain.magazine.repository;
 
 import com.example.codebase.domain.magazine.entity.Magazine;
+import com.example.codebase.domain.magazine.entity.MagazineWithIsLiked;
 import com.example.codebase.domain.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -19,4 +20,33 @@ public interface MagazineRepository extends JpaRepository<Magazine, Long> {
     @Query("SELECT m FROM Magazine m LEFT JOIN Follow f ON (f.follower= :member) WHERE f.followingMember = m.member")
     Page<Magazine> findByMemberToFollowing(Member member, PageRequest pageRequest);
 
+
+    @Query("SELECT m AS magazine, false AS isLiked FROM Magazine m WHERE m.id = :id AND m.isDeleted = false")
+    Optional<MagazineWithIsLiked> findMagazineWithIsLikedById(Long id);
+
+    @Query("SELECT m AS magazine, CASE WHEN ml.member.username = :username THEN true ELSE false END As isLiked " +
+            "FROM Magazine m LEFT JOIN MagazineLike ml ON m = ml.magazine AND ml.member.username = :username " +
+            "WHERE m.id = :id")
+    Optional<MagazineWithIsLiked> findMagazineWithLikeeByIdAndMember(Long id, String username);
+
+    @Query("SELECT m AS magazine, false AS isLiked FROM Magazine m WHERE m.isDeleted = false")
+    Page<MagazineWithIsLiked> findAllMagazineWithIsLiked(PageRequest pageRequest);
+
+    @Query("SELECT m AS magazine, CASE WHEN ml.member.username = :username THEN true ELSE false END As isLiked " +
+            "FROM Magazine m LEFT JOIN MagazineLike ml ON m = ml.magazine AND ml.member.username = :username")
+    Page<MagazineWithIsLiked> findAllMagazineWithIsLikedByUsername(String username, PageRequest pageRequest);
+
+    default Optional<MagazineWithIsLiked> findMagazineWithIsLiked(Long id, String username) {
+        if (username != null) {
+            return findMagazineWithLikeeByIdAndMember(id, username);
+        }
+        return findMagazineWithIsLikedById(id);
+    }
+
+    default Page<MagazineWithIsLiked> findAllMagazineWithIsLiked(PageRequest pageRequest, String username) {
+        if (username != null) {
+            return findAllMagazineWithIsLikedByUsername(username, pageRequest);
+        }
+        return findAllMagazineWithIsLiked(pageRequest);
+    }
 }

--- a/src/main/java/com/example/codebase/domain/magazine/repository/MagazineRepository.java
+++ b/src/main/java/com/example/codebase/domain/magazine/repository/MagazineRepository.java
@@ -27,7 +27,7 @@ public interface MagazineRepository extends JpaRepository<Magazine, Long> {
     @Query("SELECT m AS magazine, CASE WHEN ml.member.username = :username THEN true ELSE false END As isLiked " +
             "FROM Magazine m LEFT JOIN MagazineLike ml ON m = ml.magazine AND ml.member.username = :username " +
             "WHERE m.id = :id")
-    Optional<MagazineWithIsLiked> findMagazineWithLikeeByIdAndMember(Long id, String username);
+    Optional<MagazineWithIsLiked> findMagazineWithLikedByIdAndMember(Long id, String username);
 
     @Query("SELECT m AS magazine, false AS isLiked FROM Magazine m WHERE m.isDeleted = false")
     Page<MagazineWithIsLiked> findAllMagazineWithIsLiked(PageRequest pageRequest);
@@ -38,7 +38,7 @@ public interface MagazineRepository extends JpaRepository<Magazine, Long> {
 
     default Optional<MagazineWithIsLiked> findMagazineWithIsLiked(Long id, String username) {
         if (username != null) {
-            return findMagazineWithLikeeByIdAndMember(id, username);
+            return findMagazineWithLikedByIdAndMember(id, username);
         }
         return findMagazineWithIsLikedById(id);
     }

--- a/src/main/java/com/example/codebase/domain/magazine/service/MagazineService.java
+++ b/src/main/java/com/example/codebase/domain/magazine/service/MagazineService.java
@@ -3,16 +3,14 @@ package com.example.codebase.domain.magazine.service;
 import com.example.codebase.domain.magazine.dto.MagazineCommentRequest;
 import com.example.codebase.domain.magazine.dto.MagazineRequest;
 import com.example.codebase.domain.magazine.dto.MagazineResponse;
-import com.example.codebase.domain.magazine.entity.Magazine;
-import com.example.codebase.domain.magazine.entity.MagazineCategory;
-import com.example.codebase.domain.magazine.entity.MagazineComment;
-import com.example.codebase.domain.magazine.entity.MagazineMedia;
+import com.example.codebase.domain.magazine.entity.*;
 import com.example.codebase.domain.magazine.repository.MagazineCategoryRepository;
 import com.example.codebase.domain.magazine.repository.MagazineCommentRepository;
 import com.example.codebase.domain.magazine.repository.MagazineMediaRepository;
 import com.example.codebase.domain.magazine.repository.MagazineRepository;
 import com.example.codebase.domain.member.entity.Member;
 import com.example.codebase.exception.NotFoundException;
+import com.example.codebase.util.SecurityUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -54,18 +52,18 @@ public class MagazineService {
 
     @Transactional
     public MagazineResponse.Get get(Long id) {
-        Magazine magazine = magazineRepository.findById(id)
+        MagazineWithIsLiked magazine = magazineRepository.findMagazineWithIsLiked(id, SecurityUtil.getLoginUsername())
                 .orElseThrow(() -> new NotFoundException("해당 매거진이 존재하지 않습니다."));
 
-        magazine.incressView();
+        magazine.getMagazine().incressView();
 
-        magazineRepository.save(magazine);
+        magazineRepository.save(magazine.getMagazine());
         return MagazineResponse.Get.from(magazine);
     }
 
     public MagazineResponse.GetAll getAll(PageRequest pageRequest) {
-        Page<Magazine> magazines = magazineRepository.findAll(pageRequest);
-        return MagazineResponse.GetAll.from(magazines);
+        Page<MagazineWithIsLiked> magazines = magazineRepository.findAllMagazineWithIsLiked(pageRequest, SecurityUtil.getLoginUsername());
+        return MagazineResponse.GetAll.withLike(magazines);
     }
 
     @Transactional

--- a/src/test/java/com/example/codebase/controller/MagazineLikeControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/MagazineLikeControllerTest.java
@@ -3,8 +3,6 @@ package com.example.codebase.controller;
 import com.example.codebase.domain.auth.WithMockCustomUser;
 import com.example.codebase.domain.magazine.dto.MagazineCategoryRequest;
 import com.example.codebase.domain.magazine.dto.MagazineCategoryResponse;
-import com.example.codebase.domain.magazine.dto.MagazineRequest;
-import com.example.codebase.domain.magazine.dto.MagazineResponse;
 import com.example.codebase.domain.magazine.entity.Magazine;
 import com.example.codebase.domain.magazine.entity.MagazineCategory;
 import com.example.codebase.domain.magazine.repository.MagazineCategoryRepository;
@@ -13,49 +11,30 @@ import com.example.codebase.domain.magazine.service.MagazineCategoryService;
 import com.example.codebase.domain.magazine.service.MagazineLikeService;
 import com.example.codebase.domain.magazine.service.MagazineService;
 import com.example.codebase.domain.member.dto.CreateMemberDTO;
-import com.example.codebase.domain.member.entity.Authority;
 import com.example.codebase.domain.member.entity.Member;
-import com.example.codebase.domain.member.entity.MemberAuthority;
 import com.example.codebase.domain.member.repository.MemberRepository;
 import com.example.codebase.domain.member.service.MemberService;
-import com.example.codebase.jwt.TokenProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import jakarta.persistence.EntityManager;
-import jakarta.transaction.Transactional;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.TransactionStatus;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.nio.charset.StandardCharsets;
-import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
 import java.util.Random;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -150,7 +129,7 @@ class MagazineLikeControllerTest {
     public MagazineCategory createCategory() {
         Random random = new Random(System.currentTimeMillis());
 
-        String categoryName = "카테고리" + random.nextInt(300);
+        String categoryName = "카테고리" + random.nextInt(10000);
 
         char randomChar1 = (char) ('a' + random.nextInt(26));
         char randomChar2 = (char) ('a' + random.nextInt(26));
@@ -180,6 +159,54 @@ class MagazineLikeControllerTest {
     }
 
     @WithMockCustomUser(username = "testid")
+    @DisplayName("매거진 좋아요 후 전체 조회 시")
+    @Test
+    void 매거진_좋아요2() throws Exception {
+        createMagaizne(member);
+        createMagaizne(member);
+
+        // when
+        mockMvc.perform(
+                        post("/api/magazines/{magazineId}/like", magazine.getId())
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+        assertEquals(1, magazineService.get(magazine.getId()).getLikes());
+
+        // then
+        mockMvc.perform(
+                        get("/api/magazines")
+                )
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @WithMockCustomUser(username = "testid")
+    @DisplayName("매거진 좋아요 후 상세 조회 시")
+    @Test
+    void 매거진_좋아요3() throws Exception {
+
+        // when
+        mockMvc.perform(
+                        post("/api/magazines/{magazineId}/like", magazine.getId())
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+        assertEquals(1, magazineService.get(magazine.getId()).getLikes());
+
+        // then
+        mockMvc.perform(
+                        get("/api/magazines/{magazineId}", magazine.getId())
+                )
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+
+
+    @WithMockCustomUser(username = "testid")
     @DisplayName("매거진 좋아요 취소 시")
     @Test
     void 매거진_좋아요_취소() throws Exception {
@@ -197,6 +224,50 @@ class MagazineLikeControllerTest {
         // then
         assertEquals(0, magazineService.get(magazine.getId()).getLikes());
     }
+
+    @WithMockCustomUser(username = "testid")
+    @DisplayName("매거진 좋아요 취소 후 전체 조회 시")
+    @Test
+    void 매거진_좋아요_취소2() throws Exception {
+        // given
+        createMagaizne(member);
+        createMagaizne(member);
+        magazineLikeService.like(magazine.getId(), member);
+
+        // when
+        mockMvc.perform(
+                        post("/api/magazines/{magazineId}/unlike", magazine.getId())
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+        assertEquals(0, magazineService.get(magazine.getId()).getLikes());
+
+        // then
+        mockMvc.perform(
+                        get("/api/magazines")
+                )
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @WithMockCustomUser(username = "testid2")
+    @DisplayName("다른 사람이 좋아요한 게시물을 포함해 전체 조회 시")
+    @Test
+    void 좋아요3() throws Exception {
+        // given
+        createMagaizne(member);
+        createMagaizne(member);
+        magazineLikeService.like(magazine.getId(), member);
+
+        // when then
+        mockMvc.perform(
+                        get("/api/magazines")
+                )
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
 
     @WithMockCustomUser(username = "testid")
     @DisplayName("매거진 2번 좋아요 시")


### PR DESCRIPTION
## 📝 작업 내용
매거진 전체/단일 조회 시 로그인 한 사용자의 좋아요 여부를 포함한 기능을 개발했습니다.

- SecurityUtil을 컨트롤러 레이어가 아닌 서비스 레이어에서 호출 및 값을 전달하도록 개발해봤습니다.
  - **AS-IS** 컨트롤러에서 유틸 클래스 사용, 파라미터 전달, 이를 통한 비즈니스 로직 분기 (로그인했을때, 로그인안했을때)
  - **TO-BE** 서비스에서 유틸 클래스 사용, 파라미터 전달, Repository 에서 default 메서드를 사용한 DB 조회 로직 분기 (로그인했을때, 로그인안했을때)
  - 유틸성 기능을 제공하는 클래스이므로 어느 계층에서 호출해야한다는 책임이 분명하지 않습니다. 따라서 이번 기능을 개발하면서 해당 값 (로그인 정보)를 실제로 사용하는 로직과 가까이 함으로 더욱 가독성이 높은 코드를 기대할 수 있었습니다.
- MagazineRepository 인터페이스에서 default 메서드를 이용해 DB 조회 분기 로직 책임을 서비스가 아닌 DB 단에 가깝게 위치해 개발했습니다.
  - 서비스 레이어는 DB에 대해 어떤식으로 조회를 해야하는지 해당 책임을 Repository에서 수행해 기존 비즈니스 레이어의 코드를 해치지않고, Repository 레이어에서 로그인 여부에 따른 조회 방식을 분기할 수 있습니다.
  - 해당 방식을 통해 좋아요 여부를 조회하는 메서드를 재활용할 수 있고, 유지보수하기 쉬운 코드를 기대할 수 있습니다.

- SecurityUtil의 getCurrentUsername 메서드 내부 로직이 변경되었습니다.
   - Optional로 반환값을 래핑하다보니, 분기가 필요한 부분에서 ifPresent, orElse를 통해 분기하다보니, 불필요한 람다 함수를 사용해야하고, ifPresentOrElse 와 같은 Optional 제공 메서드의 반환값이 원하는 값을 반환할 수 없는 문제가 있었습니다. -> Optional은 실제 값이 없다는것을 표현하고, 이를 적절한 값으로 반환하기 위해 사용함
   - 따라서 getLoginUsername 메서드를 구현했고 String을 그대로 반환하도록 작성했습니다. 하지만 인스턴스이다 보니 Null 값을 반환할 수 있어서 사용 시 주의해야합니다.
   - SecurityUtil의 올바른 가이드라인은 다음과 같습니다. 
   - 사용자 값을 조회 시 -> getLoginUsername(String)
   - 사용자 값을 조회하는데, 없다면 예외를 던지도록 -> getCurrentUsernameValue (String, if null -> Throw exception)
   - 사용자 값을 조회하는데 값이 없다는것을 표현하도록 -> getCurrentUsername(Optional<String>)
  
## 🦾 연관된 이슈
[ART-176](https://mediaxi.atlassian.net/jira/software/projects/ART/boards/1?selectedIssue=ART-176)

## 💬리뷰 요구사항
다음과 같은 부분을 중점으로 리뷰하시면 됩니다.

- SecurityUtil 변경 사항
  - 추가적으로 getCurrentUsername 메서드를 Deprecated를 할지 고민이므로 해당 부분에 대해 의논이 필요합니다.
     - 별도로 로그인 정보를 조회할때, 예외를 발생해야한다면  getCurrentUsername().orElseThrow() 를 사용했어야했는데, 이는 getCurrentUsernameValue로 대체할 수 있고
     - 로그인 정보를 조회할때 LoginOnly와 같은 API 인가가 적용된다면 무조건 Login 정보가 보장되므로 Optional이 아닌 getLoginUsername만 사용할 수 있습니다. (또는 인가 처리가 안된 API 에서 사용해도 getCurrentUsernameValue 사용해도됨)
     - 따라서 위와 같은 이유로 이제는 getCurrentUsername를 사용할 필요가 없다고 생각합니다.
- MagazineRepository 인터페이스 변경사항


[ART-176]: https://mediaxi.atlassian.net/browse/ART-176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ