### PR TITLE
feat : 사용자가 속한 팀 반환 기능 추가

### DIFF
--- a/src/main/java/com/example/codebase/controller/TeamController.java
+++ b/src/main/java/com/example/codebase/controller/TeamController.java
@@ -88,4 +88,12 @@ public class TeamController {
         TeamUserResponse.GetAll response = teamUserService.getTeamUsers(teamId);
         return new ResponseEntity(response, HttpStatus.OK);
     }
+
+    @GetMapping("/members/{username}")
+    @Operation(summary = "유저가 속한 팀 목록 조회", description = "유저가 속한 모든 팀들을 조회합니다.")
+    public ResponseEntity getTeamsByUsername(@PathVariable String username) {
+        Member member = memberService.getEntity(username);
+        TeamUserResponse.GetAll response = teamUserService.getTeamsByUsername(member);
+        return new ResponseEntity(response, HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/example/codebase/domain/team/repository/TeamUserRepository.java
+++ b/src/main/java/com/example/codebase/domain/team/repository/TeamUserRepository.java
@@ -18,4 +18,6 @@ public interface TeamUserRepository extends JpaRepository<TeamUser, Long> {
     List<TeamUser> findAllByTeamOrderByRole(Team team);
 
     boolean existsByTeamAndMember(Team team, Member member);
+
+    List<TeamUser> findByMember(Member member);
 }

--- a/src/main/java/com/example/codebase/domain/team/service/TeamUserService.java
+++ b/src/main/java/com/example/codebase/domain/team/service/TeamUserService.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Objects;
 
 @Service
@@ -79,4 +80,9 @@ public class TeamUserService {
         teamUserRepository.save(member);
     }
 
+    @Transactional(readOnly = true)
+    public TeamUserResponse.GetAll getTeamsByUsername(Member member) {
+        List<TeamUser> teams = teamUserRepository.findByMember(member);
+        return TeamUserResponse.GetAll.from(teams);
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용
> - @GetMapping api/teams/members/{username} api 를 추가하고 테스트 코드를 작성했습니다.
> 해당 api는 팀에 관련된 기능으로 api/team-users보다 api/teams에 있는것이 더 올바른 설계 같아서 해당 위치에 추가했습니다.

## 🦾 연관된 이슈
[jirra이슈](https://mediaxi.atlassian.net/jira/software/projects/ART/issues/?jql=project%20%3D%20%22ART%22%20ORDER%20BY%20created%20DESC)

## 💬리뷰 요구사항

