### PR TITLE
[PR] 팀 정보 반환 기능 추가

### DIFF
--- a/src/main/java/com/example/codebase/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/example/codebase/domain/member/dto/MemberResponseDTO.java
@@ -90,8 +90,8 @@ public class MemberResponseDTO {
         dto.setAllowEmailReceive(member.isAllowEmailReceive());
         dto.setAllowEmailReceiveDateTime(member.getAllowEmailReceiveDatetime());
 
-        if (member.getTeamUserRoles() != null) {
-            for (TeamUser teamUser : member.getTeamUserRoles()) {
+        if (member.getTeamUser() != null) {
+            for (TeamUser teamUser : member.getTeamUser()) {
                 dto.teams.add(TeamResponse.ProfileGet.from(teamUser.getTeam()));
             }
         }

--- a/src/main/java/com/example/codebase/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/example/codebase/domain/member/dto/MemberResponseDTO.java
@@ -1,11 +1,16 @@
 package com.example.codebase.domain.member.dto;
 
 import com.example.codebase.domain.member.entity.Member;
+import com.example.codebase.domain.team.dto.TeamResponse;
+import com.example.codebase.domain.team.entity.TeamUser;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
 
 @Getter
 @Setter
@@ -50,6 +55,8 @@ public class MemberResponseDTO {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime updatedTime;
 
+    private List<TeamResponse.ProfileGet> teams = new ArrayList<>();
+
     public static MemberResponseDTO from(Member member) {
         MemberResponseDTO dto = new MemberResponseDTO();
         dto.setUsername(member.getUsername());
@@ -82,6 +89,12 @@ public class MemberResponseDTO {
 
         dto.setAllowEmailReceive(member.isAllowEmailReceive());
         dto.setAllowEmailReceiveDateTime(member.getAllowEmailReceiveDatetime());
+
+        if (member.getTeamUserRoles() != null) {
+            for (TeamUser teamUser : member.getTeamUserRoles()) {
+                dto.teams.add(TeamResponse.ProfileGet.from(teamUser.getTeam()));
+            }
+        }
 
         return dto;
     }

--- a/src/main/java/com/example/codebase/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/example/codebase/domain/member/dto/MemberResponseDTO.java
@@ -90,7 +90,7 @@ public class MemberResponseDTO {
         dto.setAllowEmailReceive(member.isAllowEmailReceive());
         dto.setAllowEmailReceiveDateTime(member.getAllowEmailReceiveDatetime());
 
-        if (member.getTeamUser() != null) {
+        if (!member.getTeamUser().isEmpty()) {
             for (TeamUser teamUser : member.getTeamUser()) {
                 dto.teams.add(TeamResponse.ProfileGet.from(teamUser.getTeam()));
             }

--- a/src/main/java/com/example/codebase/domain/member/entity/Member.java
+++ b/src/main/java/com/example/codebase/domain/member/entity/Member.java
@@ -125,7 +125,7 @@ public class Member {
 
     @Builder.Default
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE, orphanRemoval = true)
-    private List<TeamUser> teamUserRoles = new ArrayList<>();
+    private List<TeamUser> teamUser = new ArrayList<>();
 
     public static User toUser(Member member) {
         return new User(member.getUsername(), member.getPassword(), member.getAuthorities().stream()
@@ -326,11 +326,14 @@ public class Member {
 
     @PreRemove
     private void preRemove() {
-        for(TeamUser teamUser : teamUserRoles) {
+        for(TeamUser teamUser : teamUser) {
             if(teamUser.isOwner()) {
                 throw new RuntimeException("팀장인 팀이 존재합니다. 팀장을 변경하거나 팀을 삭제한 후에 시도해주세요.");
             }
         }
     }
 
+    public void addTeamUser(TeamUser teamUser) {
+        this.teamUser.add(teamUser);
+    }
 }

--- a/src/main/java/com/example/codebase/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/codebase/domain/member/service/MemberService.java
@@ -19,7 +19,7 @@ import com.example.codebase.domain.notification.repository.NotificationRepositor
 import com.example.codebase.domain.notification.repository.NotificationSettingRepository;
 import com.example.codebase.s3.S3Service;
 import com.example.codebase.util.RedisUtil;
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -164,6 +164,7 @@ public class MemberService {
         return MemberResponseDTO.from(member);
     }
 
+    @Transactional(readOnly = true)
     public MemberResponseDTO getProfile(String username) {
         Member member =
                 memberRepository.findByUsername(username).orElseThrow(NotFoundMemberException::new);

--- a/src/main/java/com/example/codebase/domain/team/dto/TeamResponse.java
+++ b/src/main/java/com/example/codebase/domain/team/dto/TeamResponse.java
@@ -46,4 +46,23 @@ public class TeamResponse {
             return get;
         }
     }
+
+    @Getter
+    @Setter
+    @Schema(name = "TeamResponse.ProfileGet", description = "팀 프로파일 조회 DTO")
+    public static class ProfileGet{
+        private Long id;
+
+        private String profileImage;
+
+        private String name;
+
+        public static TeamResponse.ProfileGet from(Team team){
+            ProfileGet profileGet = new ProfileGet();
+            profileGet.setId(team.getId());
+            profileGet.setProfileImage(team.getProfileImage());
+            profileGet.setName(team.getName());
+            return profileGet;
+        }
+    }
 }

--- a/src/main/java/com/example/codebase/domain/team/dto/TeamUserResponse.java
+++ b/src/main/java/com/example/codebase/domain/team/dto/TeamUserResponse.java
@@ -47,7 +47,7 @@ public class TeamUserResponse {
             get.setRole(teamUser.getRole());
             get.setCreatedTime(teamUser.getCreatedTime());
             get.setUpdatedTime(teamUser.getUpdatedTime());
-            get.setTeamId(teamUser.getId());
+            get.setTeamId(teamUser.getTeam().getId());
             return get;
         }
     }

--- a/src/main/java/com/example/codebase/domain/team/dto/TeamUserResponse.java
+++ b/src/main/java/com/example/codebase/domain/team/dto/TeamUserResponse.java
@@ -30,6 +30,8 @@ public class TeamUserResponse {
 
         private TeamUserRole role;
 
+        private Long teamId;
+
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         private LocalDateTime createdTime;
 
@@ -45,6 +47,7 @@ public class TeamUserResponse {
             get.setRole(teamUser.getRole());
             get.setCreatedTime(teamUser.getCreatedTime());
             get.setUpdatedTime(teamUser.getUpdatedTime());
+            get.setTeamId(teamUser.getId());
             return get;
         }
     }

--- a/src/main/java/com/example/codebase/domain/team/entity/TeamUser.java
+++ b/src/main/java/com/example/codebase/domain/team/entity/TeamUser.java
@@ -49,12 +49,14 @@ public class TeamUser {
     private LocalDateTime updatedTime = LocalDateTime.now();
 
     public static TeamUser toEntity(String position, Member member, Team team, TeamUserRole role) {
-        return TeamUser.builder()
+        TeamUser teamUser = TeamUser.builder()
                 .member(member)
                 .team(team)
                 .role(role)
                 .position(position)
                 .build();
+        member.addTeamUser(teamUser);
+        return teamUser;
     }
 
     public void validOwner() {

--- a/src/test/java/com/example/codebase/controller/TeamControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/TeamControllerTest.java
@@ -316,7 +316,10 @@ class TeamControllerTest {
         TeamUserResponse.GetAll teamUserResponse = objectMapper.readValue(response, TeamUserResponse.GetAll.class);
         assertEquals(3, teamUserResponse.getTeamUsers().size());
         assertEquals("OWNER", teamUserResponse.getTeamUsers().get(0).getRole().name());
+        assertEquals(createTeam1.getId(),teamUserResponse.getTeamUsers().get(0).getTeamId());
         assertEquals("OWNER", teamUserResponse.getTeamUsers().get(1).getRole().name());
+        assertEquals(createTeam2.getId(),teamUserResponse.getTeamUsers().get(1).getTeamId());
         assertEquals("MEMBER", teamUserResponse.getTeamUsers().get(2).getRole().name());
+        assertEquals(inviteTeam.getId(),teamUserResponse.getTeamUsers().get(2).getTeamId());
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
- get /api/teams/members/{username} 에서 팀 id가 반환안되던 문제를 해결했습니다.
- get /api/members/profile/{username}, get  /api/members/profile 에서 자신이 속해있는 팀을 반환할 수 있도록 추가했습니다.
- memberService의  @transactional을 기존 Jakarta에서 springframework에서 제공해주는 어노테이션으로 변경했습니다.

## 🦾 연관된 이슈
[jirra이슈](https://mediaxi.atlassian.net/jira/software/projects/ART/issues/?jql=project%20%3D%20%22ART%22%20ORDER%20BY%20created%20DESC)

## 💬리뷰 요구사항

