### PR TITLE
내 정보 조회 API 이관 및 사용자 정보 조회 관련 작업

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,6 +55,8 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.1.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Cleanup Gradle Cache
         if: ${{ always() }}

--- a/src/main/java/com/example/codebase/controller/AuthController.java
+++ b/src/main/java/com/example/codebase/controller/AuthController.java
@@ -1,22 +1,31 @@
 package com.example.codebase.controller;
 
-import com.example.codebase.domain.auth.dto.LoginDTO;
-import com.example.codebase.domain.auth.dto.TokenResponseDTO;
-import com.example.codebase.domain.auth.service.AuthService;
-import com.example.codebase.jwt.TokenProvider;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
+import static com.example.codebase.util.SecurityUtil.getCookieAccessTokenValue;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
+import com.example.codebase.domain.auth.dto.LoginDTO;
+import com.example.codebase.domain.auth.dto.TokenResponseDTO;
+import com.example.codebase.domain.auth.service.AuthService;
+import com.example.codebase.domain.member.dto.MemberResponseDTO;
+import com.example.codebase.domain.member.service.MemberService;
+import com.example.codebase.jwt.TokenProvider;
+import com.example.codebase.util.SecurityUtil;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-
-import static com.example.codebase.util.SecurityUtil.getCookieAccessTokenValue;
 
 @Tag(name = "Auth", description = "인증 API")
 @RestController
@@ -27,9 +36,12 @@ public class AuthController {
 
     private final AuthService authService;
 
-    public AuthController(TokenProvider tokenProvider, AuthService authService) {
+    private final MemberService memberService;
+
+    public AuthController(TokenProvider tokenProvider, AuthService authService, MemberService memberService) {
         this.tokenProvider = tokenProvider;
         this.authService = authService;
+        this.memberService = memberService;
     }
 
     @Operation(summary = "로그인", description = "로그인")
@@ -39,8 +51,8 @@ public class AuthController {
 
         // Set Cookie
         return ResponseEntity.ok()
-            .header("Set-Cookie", getCookieAccessTokenValue(responseDTO))
-            .body(responseDTO);
+                .header("Set-Cookie", getCookieAccessTokenValue(responseDTO))
+                .body(responseDTO);
     }
 
     @Operation(summary = "로그아웃", description = "로그아웃")
@@ -57,20 +69,29 @@ public class AuthController {
     public ResponseEntity refresh(@RequestBody String refreshToken) {
         TokenResponseDTO responseDTO = tokenProvider.regenerateToken(refreshToken);
         return ResponseEntity.ok()
-            .header("Set-Cookie", getCookieAccessTokenValue(responseDTO))
-            .body(responseDTO);
+                .header("Set-Cookie", getCookieAccessTokenValue(responseDTO))
+                .body(responseDTO);
     }
 
     @Operation(summary = "이메일 인증", description = "이메일 인증")
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "이메일 인증 성공"),
-        @ApiResponse(responseCode = "400", description = "이메일 인증 실패")
+            @ApiResponse(responseCode = "200", description = "이메일 인증 성공"),
+            @ApiResponse(responseCode = "400", description = "이메일 인증 실패")
     })
     @PreAuthorize("permitAll()")
     @GetMapping("/mail/authenticate")
     public ResponseEntity authenticateMailLink(
-        @RequestParam String code) {
+            @RequestParam String code) {
         authService.authenticateMail(code);
         return new ResponseEntity("이메일 인증되었습니다.", HttpStatus.OK);
+    }
+
+    @Operation(summary = "내 프로필 조회", description = "[USER] 내 프로필을 조회합니다.")
+    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER')")
+    @GetMapping("/auth/me")
+    public ResponseEntity getProfile() {
+        String username = SecurityUtil.getCurrentUsernameValue();
+        MemberResponseDTO member = memberService.getProfile(username);
+        return new ResponseEntity(member, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/codebase/controller/MemberController.java
+++ b/src/main/java/com/example/codebase/controller/MemberController.java
@@ -262,10 +262,11 @@ public class MemberController {
         return new ResponseEntity(message, HttpStatus.OK);
     }
 
-    @Operation(summary = "회원 아이디 전체 조회", description = "검색엔진 노출 용 회원 아이디 리스트를 조회합니다.")
-    @GetMapping("/username")
-    public ResponseEntity getAllUsername() {
-        List<String> usernameList = memberService.getAllUsername();
-        return new ResponseEntity(usernameList, HttpStatus.OK);
-    }
+    // @Operation(summary = "회원 아이디 전체 조회", description = "검색엔진 노출 용 회원 아이디 리스트를
+    // 조회합니다.")
+    // @GetMapping("/username")
+    // public ResponseEntity getAllUsername() {
+    // List<String> usernameList = memberService.getAllUsername();
+    // return new ResponseEntity(usernameList, HttpStatus.OK);
+    // }
 }

--- a/src/main/java/com/example/codebase/controller/MemberController.java
+++ b/src/main/java/com/example/codebase/controller/MemberController.java
@@ -34,7 +34,6 @@ public class MemberController {
 
     private final MemberService memberService;
 
-
     @Autowired
     public MemberController(MemberService memberService) {
         this.memberService = memberService;
@@ -78,7 +77,7 @@ public class MemberController {
     @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER')")
     @PutMapping("/{uesrname}")
     public ResponseEntity updateMember(@PathVariable String uesrname,
-                                       @Valid @RequestBody UpdateMemberDTO updateMemberDTO) {
+            @Valid @RequestBody UpdateMemberDTO updateMemberDTO) {
         String loginUsername = SecurityUtil.getCurrentUsername()
                 .orElseThrow(() -> new RuntimeException("로그인이 필요합니다."));
 
@@ -95,8 +94,7 @@ public class MemberController {
     @PutMapping("/{username}/picture")
     public ResponseEntity updateProfile(
             @PathVariable String username,
-            @RequestPart MultipartFile profile
-    ) throws Exception {
+            @RequestPart MultipartFile profile) throws Exception {
         String currentUsername = SecurityUtil.getCurrentUsername()
                 .orElseThrow(() -> new RuntimeException("로그인이 필요합니다."));
         if (!currentUsername.equals(username)) {
@@ -121,8 +119,7 @@ public class MemberController {
     public ResponseEntity getAllMember(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
-            @RequestParam(defaultValue = "DESC", required = false) String sortDirection
-    ) {
+            @RequestParam(defaultValue = "DESC", required = false) String sortDirection) {
         Sort sort = Sort.by(Sort.Direction.fromString(sortDirection), "createdTime");
         PageRequest pageRequest = PageRequest.of(page, size, sort);
 
@@ -130,33 +127,18 @@ public class MemberController {
         return new ResponseEntity(members, HttpStatus.OK);
     }
 
-    @Operation(summary = "역할 상태로 회원 전체 조회", description = "[ADMIN] 역할 상태로 회원 전체 조회합니다.",
-            parameters = @Parameter(
-                    name = "roleStatus",
-                    description = "역할 상태",
-                    example = "NONE | PENDING | REJECTED | ARTIST | CURATOR")
-    )
+    @Operation(summary = "역할 상태로 회원 전체 조회", description = "[ADMIN] 역할 상태로 회원 전체 조회합니다.", parameters = @Parameter(name = "roleStatus", description = "역할 상태", example = "NONE | PENDING | REJECTED | ARTIST | CURATOR"))
     @PreAuthorize("hasAnyRole('ROLE_ADMIN')")
     @GetMapping("/role-status")
     public ResponseEntity getAllRoleStatusMember(
             @RequestParam(defaultValue = "NONE") @NotBlank(message = "역할 상태는 필수입니다.") String roleStatus,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
-            @RequestParam(defaultValue = "DESC", required = false) String sortDirection
-    ) {
+            @RequestParam(defaultValue = "DESC", required = false) String sortDirection) {
         Sort sort = Sort.by(Sort.Direction.fromString(sortDirection), "createdTime");
         PageRequest pageRequest = PageRequest.of(page, size, sort);
         MembersResponseDTO members = memberService.getAllRoleStatusMember(roleStatus, pageRequest);
         return new ResponseEntity(members, HttpStatus.OK);
-    }
-
-    @Operation(summary = "내 프로필 조회", description = "[USER] 내 프로필을 조회합니다.")
-    @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER')")
-    @GetMapping("/profile")
-    public ResponseEntity getProfile() {
-        String username = SecurityUtil.getCurrentUsername().orElseThrow(() -> new RuntimeException("로그인이 필요합니다."));
-        MemberResponseDTO member = memberService.getProfile(username);
-        return new ResponseEntity(member, HttpStatus.OK);
     }
 
     @Operation(summary = "회원 프로필 조회", description = "[USER] 회원의 프로필을 조회합니다.")
@@ -199,16 +181,11 @@ public class MemberController {
         return new ResponseEntity("사용 가능한 아이디 입니다.", HttpStatus.OK);
     }
 
-    @Operation(summary = "회원 역할 상태 변경", description = "[ADMIN] 해당 회원의 역할 상태를 변경합니다.",
-            parameters = @Parameter(
-                    name = "roleStatus",
-                    description = "역할 상태",
-                    example = "NONE | ARTIST_PENDING | ARTIST_REJECTED | ARTIST | CURATOR_PENDING | CURATOR_REJECTED | CURATOR")
-    )
+    @Operation(summary = "회원 역할 상태 변경", description = "[ADMIN] 해당 회원의 역할 상태를 변경합니다.", parameters = @Parameter(name = "roleStatus", description = "역할 상태", example = "NONE | ARTIST_PENDING | ARTIST_REJECTED | ARTIST | CURATOR_PENDING | CURATOR_REJECTED | CURATOR"))
     @PreAuthorize("hasAnyRole('ROLE_ADMIN')")
     @PutMapping("/{username}/role-status")
     public ResponseEntity updateRoleStatus(@PathVariable @Valid @NotBlank String username,
-                                           @RequestParam @Valid @NotBlank(message = "역할 상태는 필수입니다.") String roleStatus) {
+            @RequestParam @Valid @NotBlank(message = "역할 상태는 필수입니다.") String roleStatus) {
         MemberResponseDTO member = memberService.updateRoleStatus(username, RoleStatus.create(roleStatus));
         return new ResponseEntity(member, HttpStatus.OK);
     }
@@ -217,7 +194,7 @@ public class MemberController {
     @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER')")
     @PutMapping("/{username}/username")
     public ResponseEntity updateUsername(@PathVariable String username,
-                                         @Valid @RequestParam UsernameDTO newUsername) {
+            @Valid @RequestParam UsernameDTO newUsername) {
         String currentUsername = SecurityUtil.getCurrentUsername()
                 .orElseThrow(() -> new RuntimeException("로그인이 필요합니다."));
         if (!SecurityUtil.isAdmin() && !currentUsername.equals(username)) { // 관리자가 아니고, 본인의 아이디가 아닐 경우
@@ -231,7 +208,7 @@ public class MemberController {
     @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")
     @PutMapping("/{username}/password")
     public ResponseEntity updatePassword(@PathVariable String username,
-                                         @NotBlank @RequestParam(value = "newPassword") String newPassword) {
+            @NotBlank @RequestParam(value = "newPassword") String newPassword) {
         String currentUsername = SecurityUtil.getCurrentUsername()
                 .orElseThrow(() -> new RuntimeException("로그인이 필요합니다."));
 
@@ -262,7 +239,7 @@ public class MemberController {
     @Operation(summary = "비밀번호 재설정", description = "비밀번호 재설정 합니다.")
     @PostMapping("/reset-password")
     public ResponseEntity resetPassword(@RequestParam @NotBlank String code,
-                                        @RequestBody PasswordResetRequestDTO password) {
+            @RequestBody PasswordResetRequestDTO password) {
 
         memberService.resetPassword(code, password);
 
@@ -273,7 +250,7 @@ public class MemberController {
     @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER')")
     @PutMapping("/{username}/email-receive")
     public ResponseEntity updateEmailReceive(@PathVariable String username,
-                                             @RequestParam boolean emailReceive) {
+            @RequestParam boolean emailReceive) {
         String currentUsername = SecurityUtil.getCurrentUsername()
                 .orElseThrow(() -> new RuntimeException("로그인이 필요합니다."));
 

--- a/src/main/java/com/example/codebase/controller/MemberController.java
+++ b/src/main/java/com/example/codebase/controller/MemberController.java
@@ -1,10 +1,8 @@
 package com.example.codebase.controller;
 
-import com.example.codebase.domain.mail.service.MailService;
 import com.example.codebase.domain.member.dto.*;
 import com.example.codebase.domain.member.entity.RoleStatus;
 import com.example.codebase.domain.member.service.MemberService;
-import com.example.codebase.domain.notification.service.NotificationSettingService;
 import com.example.codebase.exception.NotAcceptTypeException;
 import com.example.codebase.util.FileUtil;
 import com.example.codebase.util.SecurityUtil;
@@ -77,7 +75,7 @@ public class MemberController {
     @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER')")
     @PutMapping("/{uesrname}")
     public ResponseEntity updateMember(@PathVariable String uesrname,
-            @Valid @RequestBody UpdateMemberDTO updateMemberDTO) {
+                                       @Valid @RequestBody UpdateMemberDTO updateMemberDTO) {
         String loginUsername = SecurityUtil.getCurrentUsername()
                 .orElseThrow(() -> new RuntimeException("로그인이 필요합니다."));
 
@@ -185,7 +183,7 @@ public class MemberController {
     @PreAuthorize("hasAnyRole('ROLE_ADMIN')")
     @PutMapping("/{username}/role-status")
     public ResponseEntity updateRoleStatus(@PathVariable @Valid @NotBlank String username,
-            @RequestParam @Valid @NotBlank(message = "역할 상태는 필수입니다.") String roleStatus) {
+                                           @RequestParam @Valid @NotBlank(message = "역할 상태는 필수입니다.") String roleStatus) {
         MemberResponseDTO member = memberService.updateRoleStatus(username, RoleStatus.create(roleStatus));
         return new ResponseEntity(member, HttpStatus.OK);
     }
@@ -194,7 +192,7 @@ public class MemberController {
     @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER')")
     @PutMapping("/{username}/username")
     public ResponseEntity updateUsername(@PathVariable String username,
-            @Valid @RequestParam UsernameDTO newUsername) {
+                                         @Valid @RequestParam UsernameDTO newUsername) {
         String currentUsername = SecurityUtil.getCurrentUsername()
                 .orElseThrow(() -> new RuntimeException("로그인이 필요합니다."));
         if (!SecurityUtil.isAdmin() && !currentUsername.equals(username)) { // 관리자가 아니고, 본인의 아이디가 아닐 경우
@@ -208,7 +206,7 @@ public class MemberController {
     @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")
     @PutMapping("/{username}/password")
     public ResponseEntity updatePassword(@PathVariable String username,
-            @NotBlank @RequestParam(value = "newPassword") String newPassword) {
+                                         @NotBlank @RequestParam(value = "newPassword") String newPassword) {
         String currentUsername = SecurityUtil.getCurrentUsername()
                 .orElseThrow(() -> new RuntimeException("로그인이 필요합니다."));
 
@@ -239,7 +237,7 @@ public class MemberController {
     @Operation(summary = "비밀번호 재설정", description = "비밀번호 재설정 합니다.")
     @PostMapping("/reset-password")
     public ResponseEntity resetPassword(@RequestParam @NotBlank String code,
-            @RequestBody PasswordResetRequestDTO password) {
+                                        @RequestBody PasswordResetRequestDTO password) {
 
         memberService.resetPassword(code, password);
 
@@ -250,7 +248,7 @@ public class MemberController {
     @PreAuthorize("isAuthenticated() and hasAnyRole('ROLE_USER')")
     @PutMapping("/{username}/email-receive")
     public ResponseEntity updateEmailReceive(@PathVariable String username,
-            @RequestParam boolean emailReceive) {
+                                             @RequestParam boolean emailReceive) {
         String currentUsername = SecurityUtil.getCurrentUsername()
                 .orElseThrow(() -> new RuntimeException("로그인이 필요합니다."));
 

--- a/src/main/java/com/example/codebase/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/example/codebase/domain/member/dto/MemberResponseDTO.java
@@ -11,7 +11,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-
 @Getter
 @Setter
 public class MemberResponseDTO {
@@ -19,8 +18,6 @@ public class MemberResponseDTO {
     private String username;
 
     private String name;
-
-    private String email;
 
     private String picture;
 
@@ -61,7 +58,6 @@ public class MemberResponseDTO {
         MemberResponseDTO dto = new MemberResponseDTO();
         dto.setUsername(member.getUsername());
         dto.setName(member.getName());
-        dto.setEmail(member.getEmail());
         dto.setPicture(member.getPicture());
         dto.setOauthProvider(String.valueOf(member.getOauthProvider()));
         // dto.setOauthProviderId(Optional.ofNullable(member.getOauthProviderId()));

--- a/src/test/java/com/example/codebase/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/AuthControllerTest.java
@@ -67,9 +67,9 @@ class AuthControllerTest {
     @BeforeEach
     public void setUp() {
         mockMvc = MockMvcBuilders
-            .webAppContextSetup(context)
-            .apply(springSecurity())
-            .build();
+                .webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
     }
 
     public Member createOrLoadMember() {
@@ -83,13 +83,13 @@ class AuthControllerTest {
         }
 
         Member dummy = Member.builder()
-            .username("testid")
-            .password(passwordEncoder.encode("1234"))
-            .email("email")
-            .name("test")
-            .activated(activated)
-            .createdTime(LocalDateTime.now())
-            .build();
+                .username("testid")
+                .password(passwordEncoder.encode("1234"))
+                .email("email")
+                .name("test")
+                .activated(activated)
+                .createdTime(LocalDateTime.now())
+                .build();
 
         MemberAuthority memberAuthority = new MemberAuthority();
         memberAuthority.setAuthority(Authority.of("ROLE_USER"));
@@ -111,11 +111,10 @@ class AuthControllerTest {
 
         mockMvc.perform(
                 post("/api/login")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(loginDTO))
-            )
-            .andDo(print())
-            .andExpect(status().isOk());
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginDTO)))
+                .andDo(print())
+                .andExpect(status().isOk());
     }
 
     @DisplayName("토큰 재발급 시")
@@ -131,11 +130,10 @@ class AuthControllerTest {
 
         mockMvc.perform(
                 post("/api/refresh")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(refreshToken)
-            )
-            .andDo(print())
-            .andExpect(status().isOk());
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(refreshToken))
+                .andDo(print())
+                .andExpect(status().isOk());
     }
 
     @WithMockCustomUser(username = "testid")
@@ -151,10 +149,9 @@ class AuthControllerTest {
         tokenProvider.generateToken(loginDTO);
 
         mockMvc.perform(
-                post("/api/logout")
-            )
-            .andDo(print())
-            .andExpect(status().isOk());
+                post("/api/logout"))
+                .andDo(print())
+                .andExpect(status().isOk());
     }
 
     @DisplayName("사용자 이메일 코드 입력 시 ")
@@ -167,11 +164,22 @@ class AuthControllerTest {
 
         mockMvc.perform(
                 get("/api/mail/authenticate")
-                    .param("code", code)
-            )
-            .andDo(print())
-            .andExpect(status().isOk());
+                        .param("code", code))
+                .andDo(print())
+                .andExpect(status().isOk());
 
     }
 
+    @WithMockCustomUser(username = "testid", role = "USER")
+    @DisplayName("로그인한 사용자 프로필 조회 시")
+    @Test
+    void test4() throws Exception {
+        createOrLoadMember();
+
+        mockMvc.perform(
+                get("/api/auth/me")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
 }

--- a/src/test/java/com/example/codebase/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/AuthControllerTest.java
@@ -10,6 +10,7 @@ import com.example.codebase.domain.member.repository.MemberRepository;
 import com.example.codebase.jwt.TokenProvider;
 import com.example.codebase.util.RedisUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,7 +26,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
@@ -110,9 +110,9 @@ class AuthControllerTest {
         loginDTO.setPassword("1234");
 
         mockMvc.perform(
-                post("/api/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(loginDTO)))
+                        post("/api/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(loginDTO)))
                 .andDo(print())
                 .andExpect(status().isOk());
     }
@@ -129,9 +129,9 @@ class AuthControllerTest {
         String refreshToken = tokenProvider.generateToken(loginDTO).getRefreshToken();
 
         mockMvc.perform(
-                post("/api/refresh")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(refreshToken))
+                        post("/api/refresh")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(refreshToken))
                 .andDo(print())
                 .andExpect(status().isOk());
     }
@@ -149,7 +149,7 @@ class AuthControllerTest {
         tokenProvider.generateToken(loginDTO);
 
         mockMvc.perform(
-                post("/api/logout"))
+                        post("/api/logout"))
                 .andDo(print())
                 .andExpect(status().isOk());
     }
@@ -163,8 +163,8 @@ class AuthControllerTest {
         redisUtil.setDataAndExpire(code, member.getEmail(), 60 * 5 * 1000);
 
         mockMvc.perform(
-                get("/api/mail/authenticate")
-                        .param("code", code))
+                        get("/api/mail/authenticate")
+                                .param("code", code))
                 .andDo(print())
                 .andExpect(status().isOk());
 
@@ -177,8 +177,8 @@ class AuthControllerTest {
         createOrLoadMember();
 
         mockMvc.perform(
-                get("/api/auth/me")
-                        .contentType(MediaType.APPLICATION_JSON))
+                        get("/api/auth/me")
+                                .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andDo(print());
     }

--- a/src/test/java/com/example/codebase/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/MemberControllerTest.java
@@ -513,7 +513,7 @@ class MemberControllerTest {
                 .andExpect(status().isOk());
     }
 
-    @DisplayName("역 상태 별 회원 전체 조회")
+    @DisplayName("역활 별 회원 전체 조회")
     @WithMockCustomUser(username = "admin", role = "ADMIN")
     @Test
     void 승인_대기_회원_전체_조회() throws Exception {
@@ -575,20 +575,20 @@ class MemberControllerTest {
                 .andExpect(status().isOk());
     }
 
-    @DisplayName("회원 아이디 전체 조회 시")
-    @Test
-    void 회원_아이디_전체_조회() throws Exception {
-        createOrLoadMember(1);
-        createOrLoadMember(2);
-        createOrLoadMember(3);
-        createOrLoadMember(4);
-
-        mockMvc
-                .perform(
-                        get("/api/members/username"))
-                .andDo(print())
-                .andExpect(status().isOk());
-    }
+//    @DisplayName("회원 아이디 전체 조회 시")
+//    @Test
+//    void 회원_아이디_전체_조회() throws Exception {
+//        createOrLoadMember(1);
+//        createOrLoadMember(2);
+//        createOrLoadMember(3);
+//        createOrLoadMember(4);
+//
+//        mockMvc
+//                .perform(
+//                        get("/api/members/username"))
+//                .andDo(print())
+//                .andExpect(status().isOk());
+//    }
 
     @DisplayName("회원 프로필 조회시 팀 목록 반환 성공")
     @WithMockCustomUser(username = "testid1", role = "USER")
@@ -601,7 +601,7 @@ class MemberControllerTest {
 
         // when
         String response = mockMvc.perform(
-                get("/api/members/profile")
+                get("/api/auth/me")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())

--- a/src/test/java/com/example/codebase/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/MemberControllerTest.java
@@ -85,8 +85,8 @@ class MemberControllerTest {
 
     @BeforeAll
     static void setUp(@Autowired S3Mock s3Mock,
-                      @Autowired AmazonS3 amazonS3,
-                      @Autowired MockMvc mockMvc) {
+            @Autowired AmazonS3 amazonS3,
+            @Autowired MockMvc mockMvc) {
         log.info("s3Mock start");
         s3Mock.start();
         amazonS3.createBucket("media-xi-art-storage");
@@ -122,19 +122,18 @@ class MemberControllerTest {
             return testMember.get();
         }
 
-        Member dummy =
-                Member.builder()
-                        .username("testid" + index)
-                        .password(passwordEncoder.encode("1234"))
-                        .email("email" + index + "@test.com")
-                        .name("test" + index)
-                        .companyName("company" + index)
-                        .roleStatus(role)
-                        .activated(true)
-                        .allowEmailReceive(true)
-                        .allowEmailReceiveDatetime(LocalDateTime.now())
-                        .createdTime(LocalDateTime.now().plusSeconds(index))
-                        .build();
+        Member dummy = Member.builder()
+                .username("testid" + index)
+                .password(passwordEncoder.encode("1234"))
+                .email("email" + index + "@test.com")
+                .name("test" + index)
+                .companyName("company" + index)
+                .roleStatus(role)
+                .activated(true)
+                .allowEmailReceive(true)
+                .allowEmailReceiveDatetime(LocalDateTime.now())
+                .createdTime(LocalDateTime.now().plusSeconds(index))
+                .build();
 
         MemberAuthority memberAuthority = new MemberAuthority();
         memberAuthority.setAuthority(Authority.of("ROLE_USER"));
@@ -160,8 +159,7 @@ class MemberControllerTest {
                 "http://test.com/profile.jpg",
                 "http://test.com/background.jpg",
                 "팀소개",
-                "자신의 포지션, 직급"
-        );
+                "자신의 포지션, 직급");
     }
 
     @DisplayName("회원가입 API가 작동한다")
@@ -175,10 +173,9 @@ class MemberControllerTest {
         dto.setAllowEmailReceive(true);
 
         mockMvc.perform(
-                        post("/api/members")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(dto))
-                )
+                post("/api/members")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
                 .andExpect(status().isCreated())
                 .andDo(print());
     }
@@ -195,10 +192,9 @@ class MemberControllerTest {
         dto.setAllowEmailReceive(true);
 
         mockMvc.perform(
-                        post("/api/members/admin")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(dto))
-                )
+                post("/api/members/admin")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
                 .andExpect(status().isCreated())
                 .andDo(print());
     }
@@ -216,10 +212,9 @@ class MemberControllerTest {
         dto.setHistory("연혁");
 
         mockMvc.perform(
-                        post("/api/members/artist")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(dto))
-                )
+                post("/api/members/artist")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
                 .andExpect(status().isCreated())
                 .andDo(print());
     }
@@ -233,25 +228,10 @@ class MemberControllerTest {
         createOrLoadMember(3);
 
         mockMvc.perform(
-                        get("/api/members")
-                                .param("page", "0")
-                                .param("size", "10")
-                                .contentType(MediaType.APPLICATION_JSON)
-                )
-                .andExpect(status().isOk())
-                .andDo(print());
-    }
-
-    @WithMockCustomUser(username = "testid1", role = "USER")
-    @DisplayName("로그인한 사용자 프로필 조회 시")
-    @Test
-    void test4() throws Exception {
-        createOrLoadMember();
-
-        mockMvc.perform(
-                        get("/api/members/profile")
-                                .contentType(MediaType.APPLICATION_JSON)
-                )
+                get("/api/members")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andDo(print());
     }
@@ -262,9 +242,8 @@ class MemberControllerTest {
         createOrLoadMember();
 
         mockMvc.perform(
-                        get(String.format("/api/members/%s", "testid1"))
-                                .contentType(MediaType.APPLICATION_JSON)
-                )
+                get(String.format("/api/members/%s", "testid1"))
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andDo(print());
     }
@@ -282,10 +261,9 @@ class MemberControllerTest {
         dto.setHistory("history 수정");
 
         mockMvc.perform(
-                        put("/api/members/testid1")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(dto))
-                )
+                put("/api/members/testid1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
                 .andExpect(status().isOk())
                 .andDo(print());
     }
@@ -299,14 +277,14 @@ class MemberControllerTest {
         MockMultipartFile file = new MockMultipartFile("profile", "test.jpg", "image/jpg", createImageFile());
 
         mockMvc.perform(
-                        multipart("/api/members/testid1/picture")
-                                .file(file)
-                                .with(request -> {
-                                    request.setMethod("PUT");
-                                    return request;
-                                })
+                multipart("/api/members/testid1/picture")
+                        .file(file)
+                        .with(request -> {
+                            request.setMethod("PUT");
+                            return request;
+                        })
 
-                )
+        )
                 .andExpect(status().isOk())
                 .andDo(print());
     }
@@ -320,14 +298,14 @@ class MemberControllerTest {
         MockMultipartFile file = new MockMultipartFile("profile", "test.mp3", "audio/mp3", "asd".getBytes());
 
         mockMvc.perform(
-                        multipart("/api/members/testid1/picture")
-                                .file(file)
-                                .with(request -> {
-                                    request.setMethod("PUT");
-                                    return request;
-                                })
+                multipart("/api/members/testid1/picture")
+                        .file(file)
+                        .with(request -> {
+                            request.setMethod("PUT");
+                            return request;
+                        })
 
-                )
+        )
                 .andExpect(status().isUnsupportedMediaType())
                 .andDo(print());
     }
@@ -339,9 +317,8 @@ class MemberControllerTest {
         createOrLoadMember();
 
         mockMvc.perform(
-                        delete("/api/members/testid1")
-                                .contentType(MediaType.APPLICATION_JSON)
-                )
+                delete("/api/members/testid1")
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andDo(print());
     }
@@ -352,8 +329,7 @@ class MemberControllerTest {
         createOrLoadMember();
 
         mockMvc.perform(
-                        get(String.format("/api/members/email/%s", "email1"))
-                )
+                get(String.format("/api/members/email/%s", "email1")))
                 .andExpect(status().isBadRequest())
                 .andDo(print());
     }
@@ -364,8 +340,7 @@ class MemberControllerTest {
         Member member = createOrLoadMember();
 
         mockMvc.perform(
-                        get(String.format("/api/members/username/%s", member.getUsername()))
-                )
+                get(String.format("/api/members/username/%s", member.getUsername())))
                 .andDo(print())
                 .andExpect(status().isBadRequest());
     }
@@ -379,8 +354,7 @@ class MemberControllerTest {
         String status = "ARTIST";
 
         mockMvc.perform(
-                        put(String.format("/api/members/%s/role-status?roleStatus=%s", "testid1", status))
-                )
+                put(String.format("/api/members/%s/role-status?roleStatus=%s", "testid1", status)))
                 .andDo(print())
                 .andExpect(status().isOk());
     }
@@ -394,9 +368,8 @@ class MemberControllerTest {
         String status = "asd";
 
         mockMvc.perform(
-                        put("/api/members/testid1/role-status")
-                                .param("roleStatus", status)
-                )
+                put("/api/members/testid1/role-status")
+                        .param("roleStatus", status))
                 .andDo(print())
                 .andExpect(status().isBadRequest());
     }
@@ -408,8 +381,7 @@ class MemberControllerTest {
         Member loadMember = createOrLoadMember();
 
         mockMvc.perform(
-                        put(String.format("/api/members/%s/username?newUsername=%s", loadMember.getUsername(), "newid"))
-                )
+                put(String.format("/api/members/%s/username?newUsername=%s", loadMember.getUsername(), "newid")))
                 .andDo(print())
                 .andExpect(status().isOk());
     }
@@ -422,9 +394,8 @@ class MemberControllerTest {
         Member loadMember2 = createOrLoadMember(2);
 
         mockMvc.perform(
-                        put(String.format("/api/members/%s/username?newUsername=%s", loadMember1.getUsername(),
-                                loadMember2.getUsername()))
-                )
+                put(String.format("/api/members/%s/username?newUsername=%s", loadMember1.getUsername(),
+                        loadMember2.getUsername())))
                 .andDo(print())
                 .andExpect(status().isBadRequest());
     }
@@ -436,25 +407,21 @@ class MemberControllerTest {
         Member loadMember1 = createOrLoadMember();
 
         mockMvc.perform(
-                        put(String.format("/api/members/%s/username?newUsername=%s", loadMember1.getUsername(), "1"))
-                )
+                put(String.format("/api/members/%s/username?newUsername=%s", loadMember1.getUsername(), "1")))
                 .andDo(print())
                 .andExpect(status().isBadRequest());
 
         mockMvc.perform(
-                        put(String.format("/api/members/%s/username?newUsername=%s", loadMember1.getUsername(), "한글"))
-                )
+                put(String.format("/api/members/%s/username?newUsername=%s", loadMember1.getUsername(), "한글")))
                 .andDo(print())
                 .andExpect(status().isBadRequest());
 
         mockMvc.perform(
-                        put(String.format("/api/members/%s/username?newUsername=%s", loadMember1.getUsername(),
-                                "asdasdasdsadasdasdasdsa"))
-                )
+                put(String.format("/api/members/%s/username?newUsername=%s", loadMember1.getUsername(),
+                        "asdasdasdsadasdasdasdsa")))
                 .andDo(print())
                 .andExpect(status().isBadRequest());
     }
-
 
     @WithMockCustomUser(username = "testid1", role = "USER")
     @DisplayName("비밀번호 변경 시")
@@ -463,9 +430,8 @@ class MemberControllerTest {
         Member loadMember = createOrLoadMember();
 
         mockMvc.perform(
-                        put(String.format("/api/members/%s/password", loadMember.getUsername()))
-                                .param("newPassword", "newpassword123!")
-                )
+                put(String.format("/api/members/%s/password", loadMember.getUsername()))
+                        .param("newPassword", "newpassword123!"))
                 .andDo(print())
                 .andExpect(status().isOk());
     }
@@ -480,10 +446,9 @@ class MemberControllerTest {
         dto.setPassword("1234");
 
         mockMvc.perform(
-                        post("/api/members")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(dto))
-                )
+                post("/api/members")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
                 .andDo(print())
                 .andExpect(status().isBadRequest());
     }
@@ -564,8 +529,7 @@ class MemberControllerTest {
         mockMvc
                 .perform(
                         get("/api/members/role-status")
-                                .param("roleStatus", "PENDING")
-                )
+                                .param("roleStatus", "PENDING"))
                 .andDo(print())
                 .andExpect(status().isOk());
     }
@@ -586,8 +550,7 @@ class MemberControllerTest {
         mockMvc
                 .perform(
                         get("/api/members/role-status")
-                                .param("roleStatus", "asd")
-                )
+                                .param("roleStatus", "asd"))
                 .andDo(print())
                 .andExpect(status().isBadRequest());
     }
@@ -601,15 +564,13 @@ class MemberControllerTest {
         mockMvc
                 .perform(
                         put("/api/members/" + member.getUsername() + "/email-receive")
-                                .param("emailReceive", "true")
-                )
+                                .param("emailReceive", "true"))
                 .andDo(print())
                 .andExpect(status().isOk());
 
         mockMvc
                 .perform(
-                        get("/api/members/" + member.getUsername())
-                )
+                        get("/api/members/" + member.getUsername()))
                 .andDo(print())
                 .andExpect(status().isOk());
     }
@@ -624,8 +585,7 @@ class MemberControllerTest {
 
         mockMvc
                 .perform(
-                        get("/api/members/username")
-                )
+                        get("/api/members/username"))
                 .andDo(print())
                 .andExpect(status().isOk());
     }
@@ -641,9 +601,8 @@ class MemberControllerTest {
 
         // when
         String response = mockMvc.perform(
-                        get("/api/members/profile")
-                                .contentType(MediaType.APPLICATION_JSON)
-                )
+                get("/api/members/profile")
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
@@ -665,13 +624,11 @@ class MemberControllerTest {
 
         // when
         String response = mockMvc.perform(
-                        get(String.format("/api/members/%s", member.getUsername()))
-                                .contentType(MediaType.APPLICATION_JSON)
-                )
+                get(String.format("/api/members/%s", member.getUsername()))
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
-
 
         // then
         MemberResponseDTO memberResponse = objectMapper.readValue(response, MemberResponseDTO.class);

--- a/src/test/java/com/example/codebase/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/MemberControllerTest.java
@@ -12,11 +12,7 @@ import com.example.codebase.domain.member.repository.MemberAuthorityRepository;
 import com.example.codebase.domain.member.repository.MemberRepository;
 import com.example.codebase.domain.team.dto.TeamRequest;
 import com.example.codebase.domain.team.dto.TeamResponse;
-import com.example.codebase.domain.team.dto.TeamUserResponse;
-import com.example.codebase.domain.team.entity.TeamUser;
-import com.example.codebase.domain.team.repository.TeamUserRepository;
 import com.example.codebase.domain.team.service.TeamService;
-import com.example.codebase.domain.team.service.TeamUserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.findify.s3mock.S3Mock;
@@ -27,7 +23,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Role;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
@@ -85,8 +80,8 @@ class MemberControllerTest {
 
     @BeforeAll
     static void setUp(@Autowired S3Mock s3Mock,
-            @Autowired AmazonS3 amazonS3,
-            @Autowired MockMvc mockMvc) {
+                      @Autowired AmazonS3 amazonS3,
+                      @Autowired MockMvc mockMvc) {
         log.info("s3Mock start");
         s3Mock.start();
         amazonS3.createBucket("media-xi-art-storage");
@@ -173,9 +168,9 @@ class MemberControllerTest {
         dto.setAllowEmailReceive(true);
 
         mockMvc.perform(
-                post("/api/members")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(dto)))
+                        post("/api/members")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(dto)))
                 .andExpect(status().isCreated())
                 .andDo(print());
     }
@@ -192,9 +187,9 @@ class MemberControllerTest {
         dto.setAllowEmailReceive(true);
 
         mockMvc.perform(
-                post("/api/members/admin")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(dto)))
+                        post("/api/members/admin")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(dto)))
                 .andExpect(status().isCreated())
                 .andDo(print());
     }
@@ -212,9 +207,9 @@ class MemberControllerTest {
         dto.setHistory("연혁");
 
         mockMvc.perform(
-                post("/api/members/artist")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(dto)))
+                        post("/api/members/artist")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(dto)))
                 .andExpect(status().isCreated())
                 .andDo(print());
     }
@@ -228,10 +223,10 @@ class MemberControllerTest {
         createOrLoadMember(3);
 
         mockMvc.perform(
-                get("/api/members")
-                        .param("page", "0")
-                        .param("size", "10")
-                        .contentType(MediaType.APPLICATION_JSON))
+                        get("/api/members")
+                                .param("page", "0")
+                                .param("size", "10")
+                                .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andDo(print());
     }
@@ -242,8 +237,8 @@ class MemberControllerTest {
         createOrLoadMember();
 
         mockMvc.perform(
-                get(String.format("/api/members/%s", "testid1"))
-                        .contentType(MediaType.APPLICATION_JSON))
+                        get(String.format("/api/members/%s", "testid1"))
+                                .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andDo(print());
     }
@@ -261,9 +256,9 @@ class MemberControllerTest {
         dto.setHistory("history 수정");
 
         mockMvc.perform(
-                put("/api/members/testid1")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(dto)))
+                        put("/api/members/testid1")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(dto)))
                 .andExpect(status().isOk())
                 .andDo(print());
     }
@@ -277,14 +272,14 @@ class MemberControllerTest {
         MockMultipartFile file = new MockMultipartFile("profile", "test.jpg", "image/jpg", createImageFile());
 
         mockMvc.perform(
-                multipart("/api/members/testid1/picture")
-                        .file(file)
-                        .with(request -> {
-                            request.setMethod("PUT");
-                            return request;
-                        })
+                        multipart("/api/members/testid1/picture")
+                                .file(file)
+                                .with(request -> {
+                                    request.setMethod("PUT");
+                                    return request;
+                                })
 
-        )
+                )
                 .andExpect(status().isOk())
                 .andDo(print());
     }
@@ -298,14 +293,14 @@ class MemberControllerTest {
         MockMultipartFile file = new MockMultipartFile("profile", "test.mp3", "audio/mp3", "asd".getBytes());
 
         mockMvc.perform(
-                multipart("/api/members/testid1/picture")
-                        .file(file)
-                        .with(request -> {
-                            request.setMethod("PUT");
-                            return request;
-                        })
+                        multipart("/api/members/testid1/picture")
+                                .file(file)
+                                .with(request -> {
+                                    request.setMethod("PUT");
+                                    return request;
+                                })
 
-        )
+                )
                 .andExpect(status().isUnsupportedMediaType())
                 .andDo(print());
     }
@@ -317,8 +312,8 @@ class MemberControllerTest {
         createOrLoadMember();
 
         mockMvc.perform(
-                delete("/api/members/testid1")
-                        .contentType(MediaType.APPLICATION_JSON))
+                        delete("/api/members/testid1")
+                                .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andDo(print());
     }
@@ -329,7 +324,7 @@ class MemberControllerTest {
         createOrLoadMember();
 
         mockMvc.perform(
-                get(String.format("/api/members/email/%s", "email1")))
+                        get(String.format("/api/members/email/%s", "email1")))
                 .andExpect(status().isBadRequest())
                 .andDo(print());
     }
@@ -340,7 +335,7 @@ class MemberControllerTest {
         Member member = createOrLoadMember();
 
         mockMvc.perform(
-                get(String.format("/api/members/username/%s", member.getUsername())))
+                        get(String.format("/api/members/username/%s", member.getUsername())))
                 .andDo(print())
                 .andExpect(status().isBadRequest());
     }
@@ -354,7 +349,7 @@ class MemberControllerTest {
         String status = "ARTIST";
 
         mockMvc.perform(
-                put(String.format("/api/members/%s/role-status?roleStatus=%s", "testid1", status)))
+                        put(String.format("/api/members/%s/role-status?roleStatus=%s", "testid1", status)))
                 .andDo(print())
                 .andExpect(status().isOk());
     }
@@ -368,8 +363,8 @@ class MemberControllerTest {
         String status = "asd";
 
         mockMvc.perform(
-                put("/api/members/testid1/role-status")
-                        .param("roleStatus", status))
+                        put("/api/members/testid1/role-status")
+                                .param("roleStatus", status))
                 .andDo(print())
                 .andExpect(status().isBadRequest());
     }
@@ -381,7 +376,7 @@ class MemberControllerTest {
         Member loadMember = createOrLoadMember();
 
         mockMvc.perform(
-                put(String.format("/api/members/%s/username?newUsername=%s", loadMember.getUsername(), "newid")))
+                        put(String.format("/api/members/%s/username?newUsername=%s", loadMember.getUsername(), "newid")))
                 .andDo(print())
                 .andExpect(status().isOk());
     }
@@ -394,8 +389,8 @@ class MemberControllerTest {
         Member loadMember2 = createOrLoadMember(2);
 
         mockMvc.perform(
-                put(String.format("/api/members/%s/username?newUsername=%s", loadMember1.getUsername(),
-                        loadMember2.getUsername())))
+                        put(String.format("/api/members/%s/username?newUsername=%s", loadMember1.getUsername(),
+                                loadMember2.getUsername())))
                 .andDo(print())
                 .andExpect(status().isBadRequest());
     }
@@ -407,18 +402,18 @@ class MemberControllerTest {
         Member loadMember1 = createOrLoadMember();
 
         mockMvc.perform(
-                put(String.format("/api/members/%s/username?newUsername=%s", loadMember1.getUsername(), "1")))
+                        put(String.format("/api/members/%s/username?newUsername=%s", loadMember1.getUsername(), "1")))
                 .andDo(print())
                 .andExpect(status().isBadRequest());
 
         mockMvc.perform(
-                put(String.format("/api/members/%s/username?newUsername=%s", loadMember1.getUsername(), "한글")))
+                        put(String.format("/api/members/%s/username?newUsername=%s", loadMember1.getUsername(), "한글")))
                 .andDo(print())
                 .andExpect(status().isBadRequest());
 
         mockMvc.perform(
-                put(String.format("/api/members/%s/username?newUsername=%s", loadMember1.getUsername(),
-                        "asdasdasdsadasdasdasdsa")))
+                        put(String.format("/api/members/%s/username?newUsername=%s", loadMember1.getUsername(),
+                                "asdasdasdsadasdasdasdsa")))
                 .andDo(print())
                 .andExpect(status().isBadRequest());
     }
@@ -430,8 +425,8 @@ class MemberControllerTest {
         Member loadMember = createOrLoadMember();
 
         mockMvc.perform(
-                put(String.format("/api/members/%s/password", loadMember.getUsername()))
-                        .param("newPassword", "newpassword123!"))
+                        put(String.format("/api/members/%s/password", loadMember.getUsername()))
+                                .param("newPassword", "newpassword123!"))
                 .andDo(print())
                 .andExpect(status().isOk());
     }
@@ -446,9 +441,9 @@ class MemberControllerTest {
         dto.setPassword("1234");
 
         mockMvc.perform(
-                post("/api/members")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(dto)))
+                        post("/api/members")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(dto)))
                 .andDo(print())
                 .andExpect(status().isBadRequest());
     }
@@ -601,8 +596,8 @@ class MemberControllerTest {
 
         // when
         String response = mockMvc.perform(
-                get("/api/auth/me")
-                        .contentType(MediaType.APPLICATION_JSON))
+                        get("/api/auth/me")
+                                .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
@@ -624,8 +619,8 @@ class MemberControllerTest {
 
         // when
         String response = mockMvc.perform(
-                get(String.format("/api/members/%s", member.getUsername()))
-                        .contentType(MediaType.APPLICATION_JSON))
+                        get(String.format("/api/members/%s", member.getUsername()))
+                                .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);


### PR DESCRIPTION
## 📝 작업 내용
- 내 정보 조회 API 가 AuthController 에서 처리합니다.
- 사용자 정보 조회 시 민감한 개인정보를 반환하지 않도록 처리했습니다
- 사용하지 않는 민감한 API 를 제거했습니다.

## 🦾 연관된 이슈
[#161]

## 💬리뷰 요구사항
