### PR TITLE
Art 184 be 내가 속한 팀 정보 api 응답 데이터 수정

### DIFF
--- a/src/main/java/com/example/codebase/controller/MemberController.java
+++ b/src/main/java/com/example/codebase/controller/MemberController.java
@@ -291,4 +291,11 @@ public class MemberController {
         List<String> usernameList = memberService.getAllUsername();
         return new ResponseEntity(usernameList, HttpStatus.OK);
     }
+
+    @GetMapping("/{username}/teams")
+    @Operation(summary = "회원이 속한 팀 목록 조회", description = "회원이 속한 모든 팀들을 조회합니다.")
+    public ResponseEntity getTeamsByUsername(@PathVariable String username) {
+        MemberResponseDTO.TeamProfiles response = memberService.getTeamProfiles(username);
+        return new ResponseEntity(response, HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/example/codebase/controller/TeamController.java
+++ b/src/main/java/com/example/codebase/controller/TeamController.java
@@ -90,12 +90,4 @@ public class TeamController {
         TeamUserResponse.GetAll response = teamUserService.getTeamUsers(teamId);
         return new ResponseEntity(response, HttpStatus.OK);
     }
-
-    @GetMapping("/members/{username}")
-    @Operation(summary = "유저가 속한 팀 목록 조회", description = "유저가 속한 모든 팀들을 조회합니다.")
-    public ResponseEntity getTeamsByUsername(@PathVariable String username) {
-        Member member = memberService.getEntity(username);
-        List<TeamResponse.ProfileGet> response = teamUserService.getTeamsByUsername(member);
-        return new ResponseEntity(response, HttpStatus.OK);
-    }
 }

--- a/src/main/java/com/example/codebase/controller/TeamController.java
+++ b/src/main/java/com/example/codebase/controller/TeamController.java
@@ -18,6 +18,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @Tag(name = "팀 API", description = "팀과 관련된 API")
 @RequestMapping("/api/teams")
@@ -93,7 +95,7 @@ public class TeamController {
     @Operation(summary = "유저가 속한 팀 목록 조회", description = "유저가 속한 모든 팀들을 조회합니다.")
     public ResponseEntity getTeamsByUsername(@PathVariable String username) {
         Member member = memberService.getEntity(username);
-        TeamUserResponse.GetAll response = teamUserService.getTeamsByUsername(member);
+        List<TeamResponse.ProfileGet> response = teamUserService.getTeamsByUsername(member);
         return new ResponseEntity(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/codebase/controller/TeamUserController.java
+++ b/src/main/java/com/example/codebase/controller/TeamUserController.java
@@ -76,7 +76,7 @@ public class TeamUserController {
         return new ResponseEntity(response, HttpStatus.OK);
     }
 
-    @PatchMapping("{username}")
+    @PatchMapping("/{username}")
     @LoginOnly
     @Operation(summary = "팀 유저 직책 변경", description = "팀 유저의 직책을 변경합니다.")
     public ResponseEntity updateTeamUser(@PathVariable String username, @RequestParam Long teamId, @RequestBody @Valid TeamUserRequest.Update request) {

--- a/src/main/java/com/example/codebase/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/example/codebase/domain/member/dto/MemberResponseDTO.java
@@ -104,6 +104,7 @@ public class MemberResponseDTO {
 
     @Getter
     @Setter
+    @Schema(name = "MemberResponseDTO.TeamProfile", description = "팀의 기본 정보")
     public static class TeamProfile {
 
         private Long id;
@@ -123,6 +124,7 @@ public class MemberResponseDTO {
 
     @Getter
     @Setter
+    @Schema(name = "MemberResponseDTO.TeamProfileWithRole", description = "팀의 기본 정보와 속한 사용자의 역할")
     public static class TeamProfileWithRole extends TeamProfile {
         private String role;
 

--- a/src/main/java/com/example/codebase/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/example/codebase/domain/member/dto/MemberResponseDTO.java
@@ -146,7 +146,7 @@ public class MemberResponseDTO {
             TeamProfiles teamProfiles = new TeamProfiles();
             teamProfiles.setProfiles(teamUsers.stream()
                     .map(TeamProfileWithRole::from)
-                    .collect(Collectors.toList()));
+                    .toList());
             return teamProfiles;
         }
     }

--- a/src/main/java/com/example/codebase/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/example/codebase/domain/member/dto/MemberResponseDTO.java
@@ -92,7 +92,7 @@ public class MemberResponseDTO {
 
         if (!member.getTeamUser().isEmpty()) {
             for (TeamUser teamUser : member.getTeamUser()) {
-                dto.teams.add(TeamResponse.ProfileGet.from(teamUser.getTeam()));
+                dto.getTeams().add(TeamResponse.ProfileGet.from(teamUser));
             }
         }
 

--- a/src/main/java/com/example/codebase/domain/member/entity/Member.java
+++ b/src/main/java/com/example/codebase/domain/member/entity/Member.java
@@ -124,7 +124,6 @@ public class Member {
     private NotificationSetting notificationSettings;
 
     @Builder.Default
-    @OrderBy("createdTime ASC")
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<TeamUser> teamUser = new ArrayList<>();
 

--- a/src/main/java/com/example/codebase/domain/member/entity/Member.java
+++ b/src/main/java/com/example/codebase/domain/member/entity/Member.java
@@ -124,6 +124,7 @@ public class Member {
     private NotificationSetting notificationSettings;
 
     @Builder.Default
+    @OrderBy("createdTime ASC")
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<TeamUser> teamUser = new ArrayList<>();
 

--- a/src/main/java/com/example/codebase/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/codebase/domain/member/service/MemberService.java
@@ -376,4 +376,12 @@ public class MemberService {
         return memberRepository.findByUsername(username)
                 .orElseThrow(NotFoundMemberException::new);
     }
+
+    @Transactional(readOnly = true)
+    public MemberResponseDTO.TeamProfiles getTeamProfiles(String username) {
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(NotFoundMemberException::new);
+
+        return MemberResponseDTO.TeamProfiles.from(member.getTeamUser());
+    }
 }

--- a/src/main/java/com/example/codebase/domain/team/dto/TeamResponse.java
+++ b/src/main/java/com/example/codebase/domain/team/dto/TeamResponse.java
@@ -1,6 +1,8 @@
 package com.example.codebase.domain.team.dto;
 
 import com.example.codebase.domain.team.entity.Team;
+import com.example.codebase.domain.team.entity.TeamUser;
+import com.example.codebase.domain.team.entity.TeamUserRole;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
@@ -57,11 +59,14 @@ public class TeamResponse {
 
         private String name;
 
-        public static TeamResponse.ProfileGet from(Team team){
+        private TeamUserRole role;
+
+        public static TeamResponse.ProfileGet from(TeamUser teamUser){
             ProfileGet profileGet = new ProfileGet();
-            profileGet.setId(team.getId());
-            profileGet.setProfileImage(team.getProfileImage());
-            profileGet.setName(team.getName());
+            profileGet.setId(teamUser.getTeam().getId());
+            profileGet.setProfileImage(teamUser.getTeam().getProfileImage());
+            profileGet.setName(teamUser.getTeam().getName());
+            profileGet.setRole(teamUser.getRole());
             return profileGet;
         }
     }

--- a/src/main/java/com/example/codebase/domain/team/dto/TeamResponse.java
+++ b/src/main/java/com/example/codebase/domain/team/dto/TeamResponse.java
@@ -1,8 +1,6 @@
 package com.example.codebase.domain.team.dto;
 
 import com.example.codebase.domain.team.entity.Team;
-import com.example.codebase.domain.team.entity.TeamUser;
-import com.example.codebase.domain.team.entity.TeamUserRole;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
@@ -15,7 +13,7 @@ public class TeamResponse {
     @Getter
     @Setter
     @Schema(name = "TeamResponse.Get", description = "팀 조회 DTO")
-    public static class Get{
+    public static class Get {
 
         private Long id;
 
@@ -46,28 +44,6 @@ public class TeamResponse {
             get.setCreatedTime(team.getCreatedTime());
             get.setUpdatedTime(team.getUpdatedTime());
             return get;
-        }
-    }
-
-    @Getter
-    @Setter
-    @Schema(name = "TeamResponse.ProfileGet", description = "팀 프로파일 조회 DTO")
-    public static class ProfileGet{
-        private Long id;
-
-        private String profileImage;
-
-        private String name;
-
-        private TeamUserRole role;
-
-        public static TeamResponse.ProfileGet from(TeamUser teamUser){
-            ProfileGet profileGet = new ProfileGet();
-            profileGet.setId(teamUser.getTeam().getId());
-            profileGet.setProfileImage(teamUser.getTeam().getProfileImage());
-            profileGet.setName(teamUser.getTeam().getName());
-            profileGet.setRole(teamUser.getRole());
-            return profileGet;
         }
     }
 }

--- a/src/main/java/com/example/codebase/domain/team/repository/TeamUserRepository.java
+++ b/src/main/java/com/example/codebase/domain/team/repository/TeamUserRepository.java
@@ -19,5 +19,5 @@ public interface TeamUserRepository extends JpaRepository<TeamUser, Long> {
 
     boolean existsByTeamAndMember(Team team, Member member);
 
-    List<TeamUser> findByMember(Member member);
+    List<TeamUser> findByMemberOrderByCreatedTimeAsc(Member member);
 }

--- a/src/main/java/com/example/codebase/domain/team/repository/TeamUserRepository.java
+++ b/src/main/java/com/example/codebase/domain/team/repository/TeamUserRepository.java
@@ -19,5 +19,4 @@ public interface TeamUserRepository extends JpaRepository<TeamUser, Long> {
 
     boolean existsByTeamAndMember(Team team, Member member);
 
-    List<TeamUser> findByMemberOrderByCreatedTimeAsc(Member member);
 }

--- a/src/main/java/com/example/codebase/domain/team/service/TeamUserService.java
+++ b/src/main/java/com/example/codebase/domain/team/service/TeamUserService.java
@@ -81,17 +81,4 @@ public class TeamUserService {
         member.update(request);
         teamUserRepository.save(member);
     }
-
-    @Transactional(readOnly = true)
-    public List<TeamResponse.ProfileGet> getTeamsByUsername(Member member) {
-        List<TeamUser> teamUsers = teamUserRepository.findByMemberOrderByCreatedTimeAsc(member);
-
-        List<TeamResponse.ProfileGet> response = new ArrayList<>();
-        for (TeamUser teamUser : teamUsers) {
-            TeamResponse.ProfileGet profileGet = TeamResponse.ProfileGet.from(teamUser);
-            response.add(profileGet);
-        }
-
-        return response;
-    }
 }

--- a/src/main/java/com/example/codebase/domain/team/service/TeamUserService.java
+++ b/src/main/java/com/example/codebase/domain/team/service/TeamUserService.java
@@ -1,6 +1,7 @@
 package com.example.codebase.domain.team.service;
 
 import com.example.codebase.domain.member.entity.Member;
+import com.example.codebase.domain.team.dto.TeamResponse;
 import com.example.codebase.domain.team.dto.TeamUserRequest;
 import com.example.codebase.domain.team.dto.TeamUserResponse;
 import com.example.codebase.domain.team.entity.Team;
@@ -13,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -58,7 +60,7 @@ public class TeamUserService {
     }
 
     public void deleteTeamUser(TeamUser loginUser, TeamUser deleteUser) {
-        if(loginUser.isOwner() && deleteUser.isOwner()) {
+        if (loginUser.isOwner() && deleteUser.isOwner()) {
             throw new RuntimeException("팀장은 자신을 추방할 수 없습니다.");
         }
         teamUserRepository.delete(deleteUser);
@@ -72,7 +74,7 @@ public class TeamUserService {
     }
 
     public void updateTeamUser(TeamUser member, TeamUser changeMember, TeamUserRequest.Update request) {
-        if(!(Objects.equals(member.getId(), changeMember.getId())) && !member.isOwner()) {
+        if (!(Objects.equals(member.getId(), changeMember.getId())) && !member.isOwner()) {
             throw new RuntimeException("본인 또는 팀장만 정보를 수정할 수 있습니다.");
         }
 
@@ -81,8 +83,15 @@ public class TeamUserService {
     }
 
     @Transactional(readOnly = true)
-    public TeamUserResponse.GetAll getTeamsByUsername(Member member) {
-        List<TeamUser> teams = teamUserRepository.findByMember(member);
-        return TeamUserResponse.GetAll.from(teams);
+    public List<TeamResponse.ProfileGet> getTeamsByUsername(Member member) {
+        List<TeamUser> teamUsers = teamUserRepository.findByMemberOrderByCreatedTimeAsc(member);
+
+        List<TeamResponse.ProfileGet> response = new ArrayList<>();
+        for (TeamUser teamUser : teamUsers) {
+            TeamResponse.ProfileGet profileGet = TeamResponse.ProfileGet.from(teamUser);
+            response.add(profileGet);
+        }
+
+        return response;
     }
 }

--- a/src/test/java/com/example/codebase/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/MemberControllerTest.java
@@ -12,11 +12,13 @@ import com.example.codebase.domain.member.repository.MemberAuthorityRepository;
 import com.example.codebase.domain.member.repository.MemberRepository;
 import com.example.codebase.domain.team.dto.TeamRequest;
 import com.example.codebase.domain.team.dto.TeamResponse;
+import com.example.codebase.domain.team.dto.TeamUserRequest;
 import com.example.codebase.domain.team.dto.TeamUserResponse;
 import com.example.codebase.domain.team.entity.TeamUser;
 import com.example.codebase.domain.team.repository.TeamUserRepository;
 import com.example.codebase.domain.team.service.TeamService;
 import com.example.codebase.domain.team.service.TeamUserService;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.findify.s3mock.S3Mock;
@@ -44,6 +46,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -82,6 +85,9 @@ class MemberControllerTest {
 
     @Autowired
     private TeamService teamService;
+
+    @Autowired
+    private TeamUserService teamUserService;
 
     @BeforeAll
     static void setUp(@Autowired S3Mock s3Mock,
@@ -162,6 +168,13 @@ class MemberControllerTest {
                 "팀소개",
                 "자신의 포지션, 직급"
         );
+    }
+
+    public void createAndInviteMember(TeamUser loginUser, Member inviteMember) {
+        TeamUserRequest.Create request = new TeamUserRequest.Create(
+                "팀원"
+        );
+        teamUserService.addTeamUser(loginUser, inviteMember, request);
     }
 
     @DisplayName("회원가입 API가 작동한다")
@@ -651,8 +664,8 @@ class MemberControllerTest {
         // then
         MemberResponseDTO memberResponse = objectMapper.readValue(response, MemberResponseDTO.class);
         assertEquals(2, memberResponse.getTeams().size());
-        assertEquals(team1.getName(), memberResponse.getTeams().get(0).getName());
-        assertEquals(team2.getName(), memberResponse.getTeams().get(1).getName());
+        assertEquals("팀이름1", memberResponse.getTeams().get(0).getName());
+        assertEquals("팀이름2", memberResponse.getTeams().get(1).getName());
     }
 
     @DisplayName("사용자 프로필 조회 시 팀 반환 성공")
@@ -676,7 +689,37 @@ class MemberControllerTest {
         // then
         MemberResponseDTO memberResponse = objectMapper.readValue(response, MemberResponseDTO.class);
         assertEquals(2, memberResponse.getTeams().size());
-        assertEquals(team1.getName(), memberResponse.getTeams().get(0).getName());
-        assertEquals(team2.getName(), memberResponse.getTeams().get(1).getName());
+        assertEquals("팀이름1", memberResponse.getTeams().get(0).getName());
+        assertEquals("팀이름2", memberResponse.getTeams().get(1).getName());
+    }
+
+    @DisplayName("해당 유저의 팀 목록 조회 ")
+    @Test
+    void 유저가_속한_팀_조회() throws Exception {
+        //given
+        Member member = createOrLoadMember();
+        Member member2 = createOrLoadMember(2, RoleStatus.ARTIST);
+        TeamResponse.Get createTeam1 = createTeam(member, "ownerTeam1");
+        TeamResponse.Get createTeam2 = createTeam(member, "ownerTeam2");
+        TeamResponse.Get inviteTeam = createTeam(member2, "memberTeam1");
+        TeamUser teamOwner = teamUserService.findByTeamIdAndUsername(inviteTeam.getId(),member2.getUsername());
+        createAndInviteMember(teamOwner, member);
+
+        //when
+        String response = mockMvc.perform(get("/api/members/" + member.getUsername() + "/teams")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        //then
+        MemberResponseDTO.TeamProfiles teamProfiles= objectMapper.readValue(response, MemberResponseDTO.TeamProfiles.class);
+        List<MemberResponseDTO.TeamProfileWithRole> profiles = teamProfiles.getProfiles();
+        assertEquals(3, profiles.size());
+        assertEquals("OWNER", profiles.get(0).getRole());
+        assertEquals(createTeam1.getId(), profiles.get(0).getId());
+        assertEquals("OWNER", profiles.get(1).getRole());
+        assertEquals(createTeam2.getId(), profiles.get(1).getId());
+        assertEquals("MEMBER", profiles.get(2).getRole());
+        assertEquals(inviteTeam.getId(), profiles.get(2).getId());
     }
 }

--- a/src/test/java/com/example/codebase/controller/TeamControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/TeamControllerTest.java
@@ -101,13 +101,6 @@ class TeamControllerTest {
         return teamService.createTeam(createTeamRequest(name), member);
     }
 
-    public void createAndInviteMember(TeamUser loginUser, Member inviteMember) {
-        TeamUserRequest.Create request = new TeamUserRequest.Create(
-                "팀원"
-        );
-        teamUserService.addTeamUser(loginUser, inviteMember, request);
-    }
-
     @WithMockCustomUser(username = "testid", role = "USER")
     @DisplayName("팀 생성 테스트")
     @Test
@@ -294,34 +287,5 @@ class TeamControllerTest {
         TeamUserResponse.GetAll teamUserResponse = objectMapper.readValue(response, TeamUserResponse.GetAll.class);
         assertEquals(1, teamUserResponse.getTeamUsers().size());
         assertEquals("testid", teamUserResponse.getTeamUsers().get(0).getUsername());
-    }
-
-    @DisplayName("해당 유저의 팀 목록 조회 ")
-    @Test
-    void 유저가_속한_팀_조회() throws Exception {
-        //given
-        Member member = createMember("testid");
-        Member member2 = createMember("testid2");
-        TeamResponse.Get createTeam1 = createTeam(member, "ownerTeam1");
-        TeamResponse.Get createTeam2 = createTeam(member, "ownerTeam2");
-        TeamResponse.Get inviteTeam = createTeam(member2, "memberTeam1");
-        TeamUser teamOwner = teamUserService.findByTeamIdAndUsername(inviteTeam.getId(),member2.getUsername());
-        createAndInviteMember(teamOwner, member);
-
-        //when
-        String response = mockMvc.perform(get("/api/teams/members/" + member.getUsername())
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
-
-        //then
-        List<TeamResponse.ProfileGet> teamUserResponse = objectMapper.readValue(response, new TypeReference<>() {});
-        assertEquals(3, teamUserResponse.size());
-        assertEquals("OWNER",  teamUserResponse.get(0).getRole().name());
-        assertEquals(createTeam1.getId(),teamUserResponse.get(0).getId());
-        assertEquals("OWNER", teamUserResponse.get(1).getRole().name());
-        assertEquals(createTeam2.getId(),teamUserResponse.get(1).getId());
-        assertEquals("MEMBER", teamUserResponse.get(2).getRole().name());
-        assertEquals(inviteTeam.getId(),teamUserResponse.get(2).getId());
     }
 }

--- a/src/test/java/com/example/codebase/controller/TeamControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/TeamControllerTest.java
@@ -11,6 +11,7 @@ import com.example.codebase.domain.team.dto.TeamUserResponse;
 import com.example.codebase.domain.team.entity.TeamUser;
 import com.example.codebase.domain.team.service.TeamService;
 import com.example.codebase.domain.team.service.TeamUserService;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.extern.slf4j.Slf4j;
@@ -28,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
@@ -313,13 +315,13 @@ class TeamControllerTest {
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
         //then
-        TeamUserResponse.GetAll teamUserResponse = objectMapper.readValue(response, TeamUserResponse.GetAll.class);
-        assertEquals(3, teamUserResponse.getTeamUsers().size());
-        assertEquals("OWNER", teamUserResponse.getTeamUsers().get(0).getRole().name());
-        assertEquals(createTeam1.getId(),teamUserResponse.getTeamUsers().get(0).getTeamId());
-        assertEquals("OWNER", teamUserResponse.getTeamUsers().get(1).getRole().name());
-        assertEquals(createTeam2.getId(),teamUserResponse.getTeamUsers().get(1).getTeamId());
-        assertEquals("MEMBER", teamUserResponse.getTeamUsers().get(2).getRole().name());
-        assertEquals(inviteTeam.getId(),teamUserResponse.getTeamUsers().get(2).getTeamId());
+        List<TeamResponse.ProfileGet> teamUserResponse = objectMapper.readValue(response, new TypeReference<>() {});
+        assertEquals(3, teamUserResponse.size());
+        assertEquals("OWNER",  teamUserResponse.get(0).getRole().name());
+        assertEquals(createTeam1.getId(),teamUserResponse.get(0).getId());
+        assertEquals("OWNER", teamUserResponse.get(1).getRole().name());
+        assertEquals(createTeam2.getId(),teamUserResponse.get(1).getId());
+        assertEquals("MEMBER", teamUserResponse.get(2).getRole().name());
+        assertEquals(inviteTeam.getId(),teamUserResponse.get(2).getId());
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
- 내가 속한 팀 정보 api 응답 반환 데이터를 수정했습니다.
-> 해당 유저의 팀 권한 role에 대해서 추가했습니다.
```json
  "teams": [
    {
      "id": 27,
      "profileImage": "http://localhost:8080/swagger-ui/index.html#/%ED%8C%80%20API/createTeam",
      "name": "1strin1g",
      "role": "OWNER"
    },
    {
      "id": 26,
      "profileImage": "http://localhost:8080/swagger-ui/index.html#/%ED%8C%80%20API/createTeam",
      "name": "strin1g",
      "role": "OWNER"
    },
    {
      "id": 28,
      "profileImage": "http://localhost:8080/swagger-ui/index.html#/%ED%8C%80%20API/createTeam",
      "name": "1st2rin1g",
      "role": "OWNER"
    }
```
- get /teams/members/{username} 
- get api/members/{username} 

- 타 서비스 (github)를 참고하니 가입한 팀(오래된) 순서대로 반환하는 것을 확인했습니다. 일관성 있는 반환을 위해 
@orderby와 jpa 쿼리 메소드를 사용하여 가입한 팀(오래된) 순서대로 반환하도록 했습니다.

## 🦾 연관된 이슈
> [jirra이슈](https://mediaxi.atlassian.net/jira/software/projects/ART/boards/1?selectedIssue=ART-184)

## 💬리뷰 요구사항
- 변경된 response 구조에 대한 확인이 필요합니다.


