### PR TITLE
fix : 카테고리 수정 문제 해결

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ name: Test by Gradle & Code Coverage
 
 on:
   pull_request:
-    branches: [ "develop", "main" ]
+    branches: [ "develop", "main", "hotfix" ]
   workflow_call:
     secrets:
       JASYPT_ENCRYPTOR_PASSWORD:

--- a/src/main/java/com/example/codebase/controller/MagazineCategoryController.java
+++ b/src/main/java/com/example/codebase/controller/MagazineCategoryController.java
@@ -48,7 +48,7 @@ public class MagazineCategoryController {
         return new ResponseEntity(HttpStatus.NO_CONTENT);
     }
 
-    @PutMapping("/{categoryId}")
+    @PatchMapping("/{categoryId}")
     @AdminOnly
     public ResponseEntity updateCategory(@PathVariable Long categoryId, @RequestBody @Valid MagazineCategoryRequest.Update request) {
         MagazineCategoryResponse.Get category = magazineCategoryService.updateCategory(categoryId, request);

--- a/src/main/java/com/example/codebase/domain/magazine/entity/MagazineCategory.java
+++ b/src/main/java/com/example/codebase/domain/magazine/entity/MagazineCategory.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Where;
+
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -62,7 +63,7 @@ public class MagazineCategory {
                 .parent(parent)
                 .build();
 
-        if(parent != null)
+        if (parent != null)
             parent.getChildren().add(magazineCategory);
 
         return magazineCategory;
@@ -90,17 +91,19 @@ public class MagazineCategory {
         }
     }
 
-    public void update(MagazineCategoryRequest.Update request) {
+    public void update(MagazineCategoryRequest.Update request, MagazineCategory newParent) {
         Optional.ofNullable(request.getName())
                 .ifPresent(name -> this.name = name);
 
         Optional.ofNullable(request.getSlug())
                 .ifPresent(slug -> this.slug = slug);
 
+        this.changeParentCategory(newParent);
+
         this.updatedTime = LocalDateTime.now();
     }
 
-    public void changeParentCategory(MagazineCategory newParent) {
+    private void changeParentCategory(MagazineCategory newParent) {
         if (this.parent != null) {
             this.parent.getChildren().remove(this);
         }

--- a/src/main/java/com/example/codebase/domain/magazine/repository/MagazineCategoryRepository.java
+++ b/src/main/java/com/example/codebase/domain/magazine/repository/MagazineCategoryRepository.java
@@ -27,4 +27,8 @@ public interface MagazineCategoryRepository extends JpaRepository<MagazineCatego
     boolean existsBySlug(String slug);
 
     Optional<MagazineCategory> findBySlug(String slug);
+
+    boolean existsByNameAndParentAndIdNot(String name, MagazineCategory parentCategory, Long id);
+
+    boolean existsBySlugAndIdNot(String slug, Long id);
 }

--- a/src/main/java/com/example/codebase/domain/magazine/service/MagazineCategoryService.java
+++ b/src/main/java/com/example/codebase/domain/magazine/service/MagazineCategoryService.java
@@ -102,11 +102,11 @@ public class MagazineCategoryService {
 
     private void validateParentCategory(MagazineCategory category, MagazineCategory parentCategory) {
         if (parentCategory != null) {
-            parentCategory.checkDepth();
-
             if (parentCategory.equals(category)) {
                 throw new RuntimeException("부모 카테고리로 자기 자신을 참조할 수 없습니다.");
             }
+
+            parentCategory.checkDepth();
         }
     }
 

--- a/src/main/java/com/example/codebase/domain/magazine/service/MagazineCategoryService.java
+++ b/src/main/java/com/example/codebase/domain/magazine/service/MagazineCategoryService.java
@@ -5,6 +5,7 @@ import com.example.codebase.domain.magazine.dto.MagazineCategoryResponse;
 import com.example.codebase.domain.magazine.entity.MagazineCategory;
 import com.example.codebase.domain.magazine.repository.MagazineCategoryRepository;
 import com.example.codebase.exception.NotFoundException;
+import io.micrometer.common.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -91,11 +92,9 @@ public class MagazineCategoryService {
         MagazineCategory parentCategory = findParentCategory(request.getParentId());
 
         validateParentCategory(category, parentCategory);
-
         checkCategoryExists(request, category, parentCategory);
-        category.changeParentCategory(parentCategory);
 
-        category.update(request);
+        category.update(request, parentCategory);
         magazineCategoryRepository.save(category);
         return MagazineCategoryResponse.Get.from(category);
     }
@@ -103,7 +102,7 @@ public class MagazineCategoryService {
     private void validateParentCategory(MagazineCategory category, MagazineCategory parentCategory) {
         if (parentCategory != null) {
             if (parentCategory.equals(category)) {
-                throw new RuntimeException("부모 카테고리로 자기 자신을 참조할 수 없습니다.");
+                throw new RuntimeException("부모 카테고리를 해당 카테고리로 설정할 수 없습니다.");
             }
 
             parentCategory.checkDepth();

--- a/src/main/java/com/example/codebase/domain/magazine/service/MagazineCategoryService.java
+++ b/src/main/java/com/example/codebase/domain/magazine/service/MagazineCategoryService.java
@@ -36,6 +36,7 @@ public class MagazineCategoryService {
         return MagazineCategoryResponse.Create.from(category);
     }
 
+    @Nullable
     private MagazineCategory findParentCategory(Long parentId) throws NotFoundException {
         if (parentId == null) {
             return null;

--- a/src/test/java/com/example/codebase/controller/MagazineCategoryControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/MagazineCategoryControllerTest.java
@@ -504,7 +504,7 @@ class MagazineCategoryControllerTest {
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 // then
-                .andExpect(result -> assertEquals("부모 카테고리로 자기 자신을 참조할 수 없습니다.", result.getResolvedException().getMessage()));
+                .andExpect(result -> assertEquals("부모 카테고리를 해당 카테고리로 설정할 수 없습니다.", result.getResolvedException().getMessage()));
 
     }
 

--- a/src/test/java/com/example/codebase/controller/MagazineCategoryControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/MagazineCategoryControllerTest.java
@@ -36,6 +36,7 @@ import java.util.Random;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -259,7 +260,7 @@ class MagazineCategoryControllerTest {
 
         // when
         String response = mockMvc.perform(
-                        put("/api/magazine-category/" + childCategory.getId())
+                        patch("/api/magazine-category/" + childCategory.getId())
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(updateRequest))
                 )
@@ -329,7 +330,7 @@ class MagazineCategoryControllerTest {
 
         // when
         mockMvc.perform(
-                        put("/api/magazine-category/" + updateCategoryBefore.getId())
+                        patch("/api/magazine-category/" + updateCategoryBefore.getId())
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(updateRequest))
                 )
@@ -365,7 +366,7 @@ class MagazineCategoryControllerTest {
     @Test
     public void 슬러그가_같은_카테고리_수정시_중복() throws Exception {
         // given
-        MagazineCategoryResponse.Create existingCategory = magazineCategoryService.createCategory(
+        magazineCategoryService.createCategory(
                 new MagazineCategoryRequest.Create("비교카테고리", "category", null)
         );
 
@@ -377,13 +378,13 @@ class MagazineCategoryControllerTest {
 
         // when
         mockMvc.perform(
-                        put("/api/magazine-category/" + updateCategoryBefore.getId())
+                        patch("/api/magazine-category/" + updateCategoryBefore.getId())
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(updateRequest))
                 )
                 .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(result -> assertEquals("슬러그가 중복되는 카테고리가 존재합니다.", result.getResolvedException().getMessage()));
+                .andExpect(result -> assertEquals("슬러그가 중복되는 다른 카테고리가 존재합니다.", result.getResolvedException().getMessage()));
     }
 
     @WithMockCustomUser(username = "admin", role = "ADMIN")
@@ -451,13 +452,13 @@ class MagazineCategoryControllerTest {
 
         // when
         mockMvc.perform(
-                        put("/api/magazine-category/" + changeCategory.getId())
+                        patch("/api/magazine-category/" + changeCategory.getId())
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(updateRequest))
                 )
                 .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(result -> assertEquals("해당 부모 카테고리 산하 이름이 같은 카테고리가 존재합니다.", result.getResolvedException().getMessage()));
+                .andExpect(result -> assertEquals("해당 부모 카테고리 산하에 같은 이름을 가진 다른 카테고리가 존재합니다.", result.getResolvedException().getMessage()));
     }
 
     @WithMockCustomUser(username = "admin", role = "ADMIN")
@@ -480,6 +481,85 @@ class MagazineCategoryControllerTest {
                 .andExpect(result -> assertEquals("해당 카테고리에 속한 매거진이 존재합니다.", result.getResolvedException().getMessage()));
     }
 
+    @WithMockCustomUser(username = "admin", role = "ADMIN")
+    @DisplayName("매거진 카테고리를 수정시 자기 자신을 부모 카테고리로 둘수 없다.")
+    @Test
+    public void updateCategoryParentIsNotMe() throws Exception {
+        // given
+        MagazineCategory parentCategoryBefore = createCategoryAndLoad();
 
+        // 부모 카테고리를 자기 자신을 참조하도록 변경
+        MagazineCategoryResponse.Create childCategory = magazineCategoryService.createCategory(
+                new MagazineCategoryRequest.Create("수정된카테고리", "changeCategory", parentCategoryBefore.getId())
+        );
+
+        MagazineCategoryRequest.Update updateRequest = new MagazineCategoryRequest.Update("수정된 글", "updated-word", childCategory.getId());
+
+        // when
+        mockMvc.perform(
+                        patch("/api/magazine-category/" + childCategory.getId())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(updateRequest))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                // then
+                .andExpect(result -> assertEquals("부모 카테고리로 자기 자신을 참조할 수 없습니다.", result.getResolvedException().getMessage()));
+
+    }
+
+    @WithMockCustomUser(username = "admin", role = "ADMIN")
+    @DisplayName("매거진 카테고리를 수정시 자기 자신의 슬러그 중복은 제외한다")
+    @Test
+    public void updateCategorySameSlug() throws Exception {
+        // given
+        MagazineCategoryResponse.Create category = magazineCategoryService.createCategory(
+                new MagazineCategoryRequest.Create("카테고리", "category", null));
+
+        MagazineCategoryRequest.Update updateRequest = new MagazineCategoryRequest.Update("수정된 글", "category", null);
+
+        // when
+        String response = mockMvc.perform(
+                        patch("/api/magazine-category/" + category.getId())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(updateRequest))
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        // then
+        MagazineCategoryResponse.Get updatedCategory = objectMapper.readValue(response, MagazineCategoryResponse.Get.class);
+        assertEquals(updateRequest.getName(), updatedCategory.getName());
+        assertEquals(updateRequest.getSlug(), updatedCategory.getSlug());
+        assertEquals(updateRequest.getParentId(), updatedCategory.getParentCategory());
+    }
+
+    @WithMockCustomUser(username = "admin", role = "ADMIN")
+    @DisplayName("매거진 카테고리를 수정시 자기 자신의 이름 중복은 제외한다")
+    @Test
+    public void updateCategorySameName() throws Exception {
+        // given
+        MagazineCategoryResponse.Create category = magazineCategoryService.createCategory(
+                new MagazineCategoryRequest.Create("카테고리", "category", null));
+
+        MagazineCategoryRequest.Update updateRequest = new MagazineCategoryRequest.Update("카테고리", "change-category", null);
+
+        // when
+        String response = mockMvc.perform(
+                        patch("/api/magazine-category/" + category.getId())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(updateRequest))
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        // then
+        MagazineCategoryResponse.Get updatedCategory = objectMapper.readValue(response, MagazineCategoryResponse.Get.class);
+        assertEquals(updateRequest.getName(), updatedCategory.getName());
+        assertEquals(updateRequest.getSlug(), updatedCategory.getSlug());
+        assertEquals(updateRequest.getParentId(), updatedCategory.getParentCategory());
+    }
 }
 


### PR DESCRIPTION
## 📝 작업 내용
1. parentId 없이 name, slug를 수정할때 에러가 발생하던 문제를 해결했습니다.
- 해당 문제는 name, slug 중복조건에서 자기 자신을 참조하는 문제가 있어 발생하는 에러였습니다.
2. artwork, parentId, slud 가 null일 경우에 발생하던 400에러를 해결하였습니다.
3. parentId로 자기 지신의 id를 집어넣을시 발생하던 stackoverflow문제를 해결했습니다.

4. 카테고리 수정시 api가 put에서 patch로 변경되었습니다.

## 🦾 연관된 이슈
[jirra이슈](https://mediaxi.atlassian.net/jira/software/projects/ART/issues/?jql=project%20%3D%20%22ART%22%20ORDER%20BY%20created%20DESC)

