### PR TITLE
[Issue] 매거진 댓글 작성자가 수정, 삭제를 못하는 에러 해결

### DIFF
--- a/src/main/java/com/example/codebase/domain/magazine/entity/MagazineComment.java
+++ b/src/main/java/com/example/codebase/domain/magazine/entity/MagazineComment.java
@@ -121,7 +121,7 @@ public class MagazineComment {
     }
 
     public Boolean isCommentAuthor(Member member) {
-        return this.member == member;
+        return this.member.equals(member);
     }
 
     public void update(MagazineCommentRequest.Update updateComment) {

--- a/src/main/java/com/example/codebase/domain/member/entity/Member.java
+++ b/src/main/java/com/example/codebase/domain/member/entity/Member.java
@@ -336,4 +336,17 @@ public class Member {
     public void addTeamUser(TeamUser teamUser) {
         this.teamUser.add(teamUser);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Member member = (Member) o;
+        return Objects.equals(id, member.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용
![image](https://github.com/Media-XI/artscope-backend/assets/5029567/42c4c699-51c0-4043-9ff6-16ab79fef82d)

댓글 작성자인데 댓글 수정,삭제 시 요청이 처리가 되지 않는 문제를 해결했습니다.


### 문제되는 부분
![image](https://github.com/Media-XI/artscope-backend/assets/5029567/e3feab50-a05c-46d8-96a2-6129fe69c5cd)
isCommentAuthor 메서드는 두 객체의 참조값을 비교연산해 동일한 작성자인지를 체크하고 있었습니다.
하지만 MagazineComment의 Member 인스턴스는 실제로 LazyLoading 으로 인한 Proxy 객체 이므로 동일 비교 시 논리적으론 두 객체가 동일하지만 참조값이 달라서 문제가 발생했습니다.

따라서 이를 해결하기위해 equals 메서드를 재정의하였고 Primary Key 필드를 통해서 동등성 비교를 하도록 로직을 개선했습니다. 

## 🦾 연관된 이슈
https://mediaxi.atlassian.net/browse/ART-188?atlOrigin=eyJpIjoiMzliOGZlMTZlNWZmNDdmNWE1NmZlYmYyMWM2YjE2OTUiLCJwIjoiaiJ9

## 💬리뷰 요구사항
