### PR TITLE
[Issue] 매거진 수정시 categorySlug가 null을 허용하도록 변경

### DIFF
--- a/src/main/java/com/example/codebase/controller/MagazineController.java
+++ b/src/main/java/com/example/codebase/controller/MagazineController.java
@@ -163,8 +163,7 @@ public class MagazineController {
         String loginUsername = SecurityUtil.getCurrentUsername()
                 .orElseThrow(LoginRequiredException::new);
 
-        MagazineCategory category = magazineCategoryService.getEntity(magazineRequest.getCategorySlug());
-        MagazineResponse.Get magazine = magazineService.update(id, loginUsername, magazineRequest, category);
+        MagazineResponse.Get magazine = magazineService.update(id, loginUsername, magazineRequest);
 
         return new ResponseEntity(magazine, HttpStatus.OK);
     }

--- a/src/main/java/com/example/codebase/domain/magazine/dto/MagazineRequest.java
+++ b/src/main/java/com/example/codebase/domain/magazine/dto/MagazineRequest.java
@@ -62,7 +62,6 @@ public class MagazineRequest {
         @NotEmpty
         private String content;
 
-        @NotNull
         private String categorySlug;
 
         private Map<String, String> metadata;

--- a/src/main/java/com/example/codebase/domain/magazine/service/MagazineService.java
+++ b/src/main/java/com/example/codebase/domain/magazine/service/MagazineService.java
@@ -33,12 +33,15 @@ public class MagazineService {
 
     private final MagazineMediaRepository magazineMediaRepository;
 
+    private final MagazineCategoryRepository magazineCategoryRepository;
+
 
     @Autowired
-    public MagazineService(MagazineRepository magazineRepository, MagazineCommentRepository magazineCommentRepository, MagazineMediaRepository magazineMediaRepository) {
+    public MagazineService(MagazineRepository magazineRepository, MagazineCommentRepository magazineCommentRepository, MagazineMediaRepository magazineMediaRepository, MagazineCategoryRepository magazineCategoryRepository) {
         this.magazineRepository = magazineRepository;
         this.magazineCommentRepository = magazineCommentRepository;
         this.magazineMediaRepository = magazineMediaRepository;
+        this.magazineCategoryRepository = magazineCategoryRepository;
     }
 
     @Transactional
@@ -81,15 +84,25 @@ public class MagazineService {
     }
 
     @Transactional
-    public MagazineResponse.Get update(Long id, String loginUsername, MagazineRequest.Update magazineRequest, MagazineCategory magazineCategory) {
+    public MagazineResponse.Get update(Long id, String loginUsername, MagazineRequest.Update magazineRequest) {
         Magazine magazine = magazineRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("해당 매거진이 존재하지 않습니다."));
+
+        MagazineCategory magazineCategory = getCategory(magazineRequest.getCategorySlug(), magazine.getCategory());
 
         validateOwner(loginUsername, magazine);
 
         magazine.update(magazineRequest, magazineCategory);
 
         return MagazineResponse.Get.from(magazine);
+    }
+
+    private MagazineCategory getCategory(String categorySlug, MagazineCategory defaultCategory) {
+        if (categorySlug != null) {
+            return magazineCategoryRepository.findBySlug(categorySlug)
+                    .orElseThrow(() -> new NotFoundException("해당 카테고리가 존재하지 않습니다."));
+        }
+        return defaultCategory;
     }
 
     private void validateOwner(String loginUsername, Magazine magazine) {

--- a/src/test/java/com/example/codebase/controller/MagazineControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/MagazineControllerTest.java
@@ -1025,4 +1025,37 @@ class MagazineControllerTest {
         //then
         assertTrue(response.contains("잠시 후 다시 시도해주세요."));
     }
+
+    @WithMockCustomUser(username = "testid", role = "USER")
+    @DisplayName("매거진 수정시 slug가 없는 경우")
+    @Test
+    void 매거진_수정시_slug가_없는경우() throws Exception {
+        // given
+        Member author = createMember("testid");
+        MagazineResponse.Get magazine = createMagaizne(author);
+        String originalCategorySlug = magazine.getCategorySlug();
+
+        MagazineRequest.Update magazineRequest = new MagazineRequest.Update();
+        magazineRequest.setTitle("수정된 제목");
+        magazineRequest.setContent("수정된 내용");
+        magazineRequest.setCategorySlug(null);
+
+        // when
+        String response = mockMvc.perform(
+                        put("/api/magazines/" + magazine.getId())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(magazineRequest))
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        // then
+        MagazineResponse.Get magazineResponse = objectMapper.readValue(response, MagazineResponse.Get.class);
+        assertEquals(magazine.getId(), magazineResponse.getId());
+        assertEquals(magazineRequest.getTitle(), magazineResponse.getTitle());
+        assertEquals(magazineRequest.getContent(), magazineResponse.getContent());
+        assertEquals(originalCategorySlug, magazineResponse.getCategorySlug());
+    }
+
 }


### PR DESCRIPTION
## 📝 작업 내용
> 매거진 수정시 MagazineRequest.Update에서 categorySlug가 null일경우 기존의 slug를 반영하도록 수정했습니다.
> 추후에 확장과 변경이 용이하도록 더 나은 magazineCategory를 조회 및 magazine에서 category를 수정하는 로직에 대해서 고민해보겠습니다.

## 🦾 연관된 이슈
[jirra이슈](https://mediaxi.atlassian.net/jira/software/projects/ART/issues/ART-187?jql=project%20%3D%20%22ART%22%20ORDER%20BY%20created%20DESC)

## 💬리뷰 요구사항

