### PR TITLE
fix: 직책 변경시 자기 자신이 변경되던 문제 해결

### DIFF
--- a/src/main/java/com/example/codebase/domain/team/service/TeamUserService.java
+++ b/src/main/java/com/example/codebase/domain/team/service/TeamUserService.java
@@ -78,7 +78,7 @@ public class TeamUserService {
             throw new RuntimeException("본인 또는 팀장만 정보를 수정할 수 있습니다.");
         }
 
-        member.update(request);
-        teamUserRepository.save(member);
+        changeMember.update(request);
+        teamUserRepository.save(changeMember);
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
- 팀 유저 직책 변경 api - > patch : team-users/{username} api 문제해결
> 직책 변경시 자기 자신이 변경되는 문제를 해결했습니다.
<img width="808" alt="image" src="https://github.com/Media-XI/artscope-backend/assets/128161745/9d1e6c12-acd4-4b95-a451-66e64d11a9e3">


## 🦾 연관된 이슈
[jirra이슈](https://mediaxi.atlassian.net/jira/software/projects/ART/issues/ART-189?jql=project%20%3D%20%22ART%22%20ORDER%20BY%20created%20DESC)

## 💬리뷰 요구사항
