### PR TITLE
feat : 팀 정보 조회시 owner의 username을 반환하도록 수정

### DIFF
--- a/src/main/java/com/example/codebase/controller/TeamController.java
+++ b/src/main/java/com/example/codebase/controller/TeamController.java
@@ -6,6 +6,7 @@ import com.example.codebase.domain.member.service.MemberService;
 import com.example.codebase.domain.team.dto.TeamRequest;
 import com.example.codebase.domain.team.dto.TeamResponse;
 import com.example.codebase.domain.team.dto.TeamUserResponse;
+import com.example.codebase.domain.team.entity.Team;
 import com.example.codebase.domain.team.entity.TeamUser;
 import com.example.codebase.domain.team.service.TeamService;
 import com.example.codebase.domain.team.service.TeamUserService;
@@ -17,8 +18,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @Tag(name = "팀 API", description = "팀과 관련된 API")
@@ -45,7 +44,9 @@ public class TeamController {
         String loginUsername = SecurityUtil.getCurrentUsernameValue();
         Member member = memberService.getEntity(loginUsername);
 
-        TeamResponse.Get response = teamService.createTeam(request, member);
+        Team team = teamService.createTeam(request, member);
+        TeamUser teamUser = teamUserService.findTeamOwnerByTeam(team);
+        TeamResponse.Get response = TeamResponse.Get.of(team,teamUser);
 
         return new ResponseEntity(response, HttpStatus.CREATED);
     }
@@ -53,7 +54,9 @@ public class TeamController {
     @GetMapping("/{teamId}")
     @Operation(summary = "팀 정보 조회", description = "팀을 조회합니다.")
     public ResponseEntity getTeam(@PathVariable Long teamId) {
-        TeamResponse.Get response = teamService.getTeam(teamId);
+        Team team = teamService.getTeam(teamId);
+        TeamUser teamUser = teamUserService.findTeamOwnerByTeam(team);
+        TeamResponse.Get response = TeamResponse.Get.of(team,teamUser);
 
         return new ResponseEntity(response, HttpStatus.OK);
     }
@@ -66,7 +69,9 @@ public class TeamController {
         TeamUser member = teamUserService.findByTeamIdAndUsername(teamId, loginUsername);
         member.validOwner();
 
-        TeamResponse.Get response = teamService.updateTeam(request, member);
+        Team team = teamService.updateTeam(request, member);
+        TeamUser teamUser = teamUserService.findTeamOwnerByTeam(team);
+        TeamResponse.Get response = TeamResponse.Get.of(team,teamUser);
 
         return new ResponseEntity(response, HttpStatus.OK);
     }

--- a/src/main/java/com/example/codebase/domain/team/dto/TeamResponse.java
+++ b/src/main/java/com/example/codebase/domain/team/dto/TeamResponse.java
@@ -1,6 +1,7 @@
 package com.example.codebase.domain.team.dto;
 
 import com.example.codebase.domain.team.entity.Team;
+import com.example.codebase.domain.team.entity.TeamUser;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
@@ -27,13 +28,15 @@ public class TeamResponse {
 
         private String name;
 
+        private String ownerUsername;
+
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
         private LocalDateTime createdTime;
 
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
         private LocalDateTime updatedTime;
 
-        public static TeamResponse.Get from(Team team) {
+        public static Get of(Team team, TeamUser teamUser) {
             Get get = new Get();
             get.setId(team.getId());
             get.setDescription(team.getDescription());
@@ -43,6 +46,7 @@ public class TeamResponse {
             get.setName(team.getName());
             get.setCreatedTime(team.getCreatedTime());
             get.setUpdatedTime(team.getUpdatedTime());
+            get.setOwnerUsername(teamUser.getMember().getUsername());
             return get;
         }
     }

--- a/src/main/java/com/example/codebase/domain/team/repository/TeamUserRepository.java
+++ b/src/main/java/com/example/codebase/domain/team/repository/TeamUserRepository.java
@@ -3,6 +3,7 @@ package com.example.codebase.domain.team.repository;
 import com.example.codebase.domain.member.entity.Member;
 import com.example.codebase.domain.team.entity.Team;
 import com.example.codebase.domain.team.entity.TeamUser;
+import com.example.codebase.domain.team.entity.TeamUserRole;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -19,4 +20,5 @@ public interface TeamUserRepository extends JpaRepository<TeamUser, Long> {
 
     boolean existsByTeamAndMember(Team team, Member member);
 
+    Optional<TeamUser> findByTeamIdAndRole(Long id, TeamUserRole teamUserRole);
 }

--- a/src/main/java/com/example/codebase/domain/team/service/TeamService.java
+++ b/src/main/java/com/example/codebase/domain/team/service/TeamService.java
@@ -42,12 +42,6 @@ public class TeamService {
                 .orElseThrow(() -> new NotFoundException("팀이 존재하지 않습니다."));
     }
 
-    @Transactional(readOnly = true)
-    public Team getEntity(String teamName) {
-        return teamRepository.findByName(teamName)
-                .orElseThrow(() -> new NotFoundException("팀이 존재하지 않습니다."));
-    }
-
     public Team updateTeam(TeamRequest.Update request, TeamUser teamUser) {
         Team team = teamUser.getTeam();
 

--- a/src/main/java/com/example/codebase/domain/team/service/TeamService.java
+++ b/src/main/java/com/example/codebase/domain/team/service/TeamService.java
@@ -2,7 +2,6 @@ package com.example.codebase.domain.team.service;
 
 import com.example.codebase.domain.member.entity.Member;
 import com.example.codebase.domain.team.dto.TeamRequest;
-import com.example.codebase.domain.team.dto.TeamResponse;
 import com.example.codebase.domain.team.entity.Team;
 import com.example.codebase.domain.team.entity.TeamUser;
 import com.example.codebase.domain.team.entity.TeamUserRole;
@@ -23,8 +22,8 @@ public class TeamService {
         this.teamRepository = teamRepository;
     }
 
-    public TeamResponse.Get createTeam(TeamRequest.Create request, Member member) {
-        if(teamRepository.existsByName(request.getName())) {
+    public Team createTeam(TeamRequest.Create request, Member member) {
+        if (teamRepository.existsByName(request.getName())) {
             throw new RuntimeException("이미 존재하는 팀 이름입니다.");
         }
 
@@ -34,21 +33,22 @@ public class TeamService {
         team.addTeamUser(teamUser);
 
         teamRepository.save(team);
-        return TeamResponse.Get.from(team);
+        return team;
     }
 
     @Transactional(readOnly = true)
-    public TeamResponse.Get getTeam(Long teamId) {
-        Team team = teamRepository.findById(teamId).orElseThrow(() -> new NotFoundException("팀이 존재하지 않습니다."));
-        return TeamResponse.Get.from(team);
+    public Team getTeam(Long teamId) {
+        return teamRepository.findById(teamId)
+                .orElseThrow(() -> new NotFoundException("팀이 존재하지 않습니다."));
     }
 
     @Transactional(readOnly = true)
     public Team getEntity(String teamName) {
-        return teamRepository.findByName(teamName).orElseThrow(() -> new NotFoundException("팀이 존재하지 않습니다."));
+        return teamRepository.findByName(teamName)
+                .orElseThrow(() -> new NotFoundException("팀이 존재하지 않습니다."));
     }
 
-    public TeamResponse.Get updateTeam(TeamRequest.Update request, TeamUser teamUser) {
+    public Team updateTeam(TeamRequest.Update request, TeamUser teamUser) {
         Team team = teamUser.getTeam();
 
         if (teamRepository.existsByNameAndIdNot(request.getName(), team.getId())) {
@@ -57,7 +57,7 @@ public class TeamService {
 
         team.update(request);
         teamRepository.save(team);
-        return TeamResponse.Get.from(team);
+        return team;
     }
 
     public void deleteTeam(TeamUser teamUser) {

--- a/src/main/java/com/example/codebase/domain/team/service/TeamUserService.java
+++ b/src/main/java/com/example/codebase/domain/team/service/TeamUserService.java
@@ -1,7 +1,6 @@
 package com.example.codebase.domain.team.service;
 
 import com.example.codebase.domain.member.entity.Member;
-import com.example.codebase.domain.team.dto.TeamResponse;
 import com.example.codebase.domain.team.dto.TeamUserRequest;
 import com.example.codebase.domain.team.dto.TeamUserResponse;
 import com.example.codebase.domain.team.entity.Team;
@@ -14,8 +13,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 @Service
@@ -80,5 +77,11 @@ public class TeamUserService {
 
         member.update(request);
         teamUserRepository.save(member);
+    }
+
+    @Transactional(readOnly = true)
+    public TeamUser findTeamOwnerByTeam(Team team) {
+        return teamUserRepository.findByTeamIdAndRole(team.getId(), TeamUserRole.OWNER)
+                .orElseThrow(() -> new NotFoundException("팀장을 찾을 수 없습니다."));
     }
 }

--- a/src/test/java/com/example/codebase/controller/MagazineControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/MagazineControllerTest.java
@@ -10,8 +10,8 @@ import com.example.codebase.domain.member.dto.CreateMemberDTO;
 import com.example.codebase.domain.member.entity.Member;
 import com.example.codebase.domain.member.service.MemberService;
 import com.example.codebase.domain.team.dto.TeamRequest;
-import com.example.codebase.domain.team.dto.TeamResponse;
 import com.example.codebase.domain.team.dto.TeamUserRequest;
+import com.example.codebase.domain.team.entity.Team;
 import com.example.codebase.domain.team.entity.TeamUser;
 import com.example.codebase.domain.team.service.TeamService;
 import com.example.codebase.domain.team.service.TeamUserService;
@@ -175,7 +175,7 @@ class MagazineControllerTest {
         );
     }
 
-    public TeamResponse.Get createTeam(Member member, String name) {
+    public Team createTeam(Member member, String name) {
         return teamService.createTeam(createTeamRequest(name), member);
     }
 
@@ -840,7 +840,7 @@ class MagazineControllerTest {
     void 팀_매거진_생성() throws Exception {
         // given
         Member member = createMember("testid");
-        TeamResponse.Get team = createTeam(member, "팀이름");
+        Team team = createTeam(member, "팀이름");
         TeamUser teamUser = teamUserService.findByTeamIdAndUsername(team.getId(), member.getUsername());
 
         MagazineCategoryRequest.Create request = new MagazineCategoryRequest.Create("글", "slug", null);
@@ -880,7 +880,7 @@ class MagazineControllerTest {
     void 팀_매거진_생성시_해당_팀_유저가_아닌경우_실패() throws Exception {
         // given
         Member member = createMember("admin");
-        TeamResponse.Get team = createTeam(member, "팀이름");
+        Team team = createTeam(member, "팀이름");
         TeamUser teamUser = teamUserService.findByTeamIdAndUsername(team.getId(), member.getUsername());
 
         createMember("testid");
@@ -914,7 +914,7 @@ class MagazineControllerTest {
     void 팀_매거진_생성시_urn에_string을_기입_할_경우_실패() throws Exception {
         // given
         Member member = createMember("admin");
-        TeamResponse.Get team = createTeam(member, "팀이름");
+        Team team = createTeam(member, "팀이름");
         TeamUser teamUser = teamUserService.findByTeamIdAndUsername(team.getId(), member.getUsername());
 
         createMember("testid");

--- a/src/test/java/com/example/codebase/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/MemberControllerTest.java
@@ -15,6 +15,7 @@ import com.example.codebase.domain.team.dto.TeamResponse;
 
 import com.example.codebase.domain.team.dto.TeamUserRequest;
 import com.example.codebase.domain.team.dto.TeamUserResponse;
+import com.example.codebase.domain.team.entity.Team;
 import com.example.codebase.domain.team.entity.TeamUser;
 import com.example.codebase.domain.team.repository.TeamUserRepository;
 import com.example.codebase.domain.team.service.TeamService;
@@ -155,7 +156,7 @@ class MemberControllerTest {
         return Files.readAllBytes(file.toPath());
     }
 
-    public TeamResponse.Get createTeam(Member member, String name) {
+    public Team createTeam(Member member, String name) {
         return teamService.createTeam(createTeamRequest(name), member);
     }
 
@@ -610,8 +611,8 @@ class MemberControllerTest {
     void 회원_프로필_팀_조회시_팀_반환_확인() throws Exception {
         // given
         Member member = createOrLoadMember();
-        TeamResponse.Get team1 = createTeam(member, "팀이름1");
-        TeamResponse.Get team2 = createTeam(member, "팀이름2");
+        Team team1 = createTeam(member, "팀이름1");
+        Team team2 = createTeam(member, "팀이름2");
 
         // when
         String response = mockMvc.perform(
@@ -633,8 +634,8 @@ class MemberControllerTest {
     void 사용자_프로필_조회시_팀_반환_확인() throws Exception {
         // given
         Member member = createOrLoadMember();
-        TeamResponse.Get team1 = createTeam(member, "팀이름1");
-        TeamResponse.Get team2 = createTeam(member, "팀이름2");
+        Team team1 = createTeam(member, "팀이름1");
+        Team team2 = createTeam(member, "팀이름2");
 
         // when
         String response = mockMvc.perform(
@@ -657,9 +658,9 @@ class MemberControllerTest {
         //given
         Member member = createOrLoadMember();
         Member member2 = createOrLoadMember(2, RoleStatus.ARTIST);
-        TeamResponse.Get createTeam1 = createTeam(member, "ownerTeam1");
-        TeamResponse.Get createTeam2 = createTeam(member, "ownerTeam2");
-        TeamResponse.Get inviteTeam = createTeam(member2, "memberTeam1");
+        Team createTeam1 = createTeam(member, "ownerTeam1");
+        Team createTeam2 = createTeam(member, "ownerTeam2");
+        Team inviteTeam = createTeam(member2, "memberTeam1");
         TeamUser teamOwner = teamUserService.findByTeamIdAndUsername(inviteTeam.getId(),member2.getUsername());
         createAndInviteMember(teamOwner, member);
 

--- a/src/test/java/com/example/codebase/controller/TeamControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/TeamControllerTest.java
@@ -8,6 +8,7 @@ import com.example.codebase.domain.team.dto.TeamRequest;
 import com.example.codebase.domain.team.dto.TeamResponse;
 import com.example.codebase.domain.team.dto.TeamUserRequest;
 import com.example.codebase.domain.team.dto.TeamUserResponse;
+import com.example.codebase.domain.team.entity.Team;
 import com.example.codebase.domain.team.entity.TeamUser;
 import com.example.codebase.domain.team.service.TeamService;
 import com.example.codebase.domain.team.service.TeamUserService;
@@ -97,7 +98,7 @@ class TeamControllerTest {
         return request;
     }
 
-    public TeamResponse.Get createTeam(Member member, String name) {
+    public Team createTeam(Member member, String name) {
         return teamService.createTeam(createTeamRequest(name), member);
     }
 
@@ -125,6 +126,7 @@ class TeamControllerTest {
         assertEquals(request.getAddress(), teamResponse.getAddress());
         assertEquals(request.getProfileImage(), teamResponse.getProfileImage());
         assertEquals(request.getBackgroundImage(), teamResponse.getBackgroundImage());
+        assertEquals(member.getUsername(), teamResponse.getOwnerUsername());
     }
 
     @WithMockCustomUser(username = "testid", role = "USER")
@@ -152,7 +154,7 @@ class TeamControllerTest {
     void 팀_정보_상세_조회() throws Exception {
         // given
         Member member = createMember("testid");
-        TeamResponse.Get team = createTeam(member, "팀생성");
+        Team team = createTeam(member, "팀생성");
 
         String response = mockMvc.perform(
                         get("/api/teams/" + team.getId())
@@ -167,6 +169,7 @@ class TeamControllerTest {
         assertEquals(team.getAddress(), teamResponse.getAddress());
         assertEquals(team.getProfileImage(), teamResponse.getProfileImage());
         assertEquals(team.getBackgroundImage(), teamResponse.getBackgroundImage());
+        assertEquals(member.getUsername(), teamResponse.getOwnerUsername());
     }
 
     @DisplayName("팀 정보 수정")
@@ -175,7 +178,7 @@ class TeamControllerTest {
     void 팀_정보_수정() throws Exception {
         // given
         Member member = createMember("testid");
-        TeamResponse.Get team = createTeam(member, "팀수정");
+        Team team = createTeam(member, "팀수정");
 
         TeamRequest.Update request = new TeamRequest.Update(
                 "수정된팀이름",
@@ -201,6 +204,7 @@ class TeamControllerTest {
         assertEquals(request.getProfileImage(), teamResponse.getProfileImage());
         assertEquals(request.getBackgroundImage(), teamResponse.getBackgroundImage());
         assertEquals(request.getDescription(), teamResponse.getDescription());
+        assertEquals(member.getUsername(), teamResponse.getOwnerUsername());
     }
 
     @DisplayName("이미 존재하는 팀 이름이 있을 때 팀 정보 수정 실패")
@@ -210,7 +214,7 @@ class TeamControllerTest {
         // given
         Member member = createMember("testid");
         createTeam(member, "중복된팀이름");
-        TeamResponse.Get team = createTeam(member, "테스트이름");
+        Team team = createTeam(member, "테스트이름");
         TeamRequest.Update request = new TeamRequest.Update(
                 "중복된팀이름",
                 "팀 주소",
@@ -235,7 +239,7 @@ class TeamControllerTest {
     void 기존의_팀과_동일한_이름으로_팀_정보_수정시() throws Exception {
         // given
         Member member = createMember("testid");
-        TeamResponse.Get team = createTeam(member, "팀이름");
+        Team team = createTeam(member, "팀이름");
         TeamRequest.Update request = new TeamRequest.Update(
                 "팀이름",
                 "팀 주소",
@@ -259,7 +263,7 @@ class TeamControllerTest {
     void 팀_삭제() throws Exception {
         // given
         Member member = createMember("testid");
-        TeamResponse.Get team = createTeam(member, "팀이름");
+        Team team = createTeam(member, "팀이름");
 
         // when
         mockMvc.perform(
@@ -275,7 +279,7 @@ class TeamControllerTest {
     void 팀_소속_유저_조회() throws Exception {
         // given
         Member member = createMember("testid");
-        TeamResponse.Get team = createTeam(member, "팀이름");
+        Team team = createTeam(member, "팀이름");
 
         // when
         String response = mockMvc.perform(get("/api/teams/" + team.getId() + "/people")

--- a/src/test/java/com/example/codebase/controller/TeamUserControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/TeamUserControllerTest.java
@@ -5,9 +5,9 @@ import com.example.codebase.domain.member.dto.CreateMemberDTO;
 import com.example.codebase.domain.member.entity.Member;
 import com.example.codebase.domain.member.service.MemberService;
 import com.example.codebase.domain.team.dto.TeamRequest;
-import com.example.codebase.domain.team.dto.TeamResponse;
 import com.example.codebase.domain.team.dto.TeamUserRequest;
 import com.example.codebase.domain.team.dto.TeamUserResponse;
+import com.example.codebase.domain.team.entity.Team;
 import com.example.codebase.domain.team.entity.TeamUser;
 import com.example.codebase.domain.team.service.TeamService;
 import com.example.codebase.domain.team.service.TeamUserService;
@@ -92,7 +92,7 @@ class TeamUserControllerTest {
         );
     }
 
-    public TeamResponse.Get createTeam(Member member, String name) {
+    public Team createTeam(Member member, String name) {
         return teamService.createTeam(createTeamRequest(name), member);
     }
 
@@ -109,7 +109,7 @@ class TeamUserControllerTest {
     void 팀_소속_유저_추가() throws Exception {
         // given
         Member member = createMember("testid");
-        TeamResponse.Get team = createTeam(member, "팀이름");
+        Team team = createTeam(member, "팀이름");
         Member inviteMember = createMember("inviteMember");
 
         TeamUserRequest.Create request = new TeamUserRequest.Create(
@@ -139,7 +139,7 @@ class TeamUserControllerTest {
     void 팀_소속_유저_삭제() throws Exception {
         // given
         Member member = createMember("testid");
-        TeamResponse.Get team = createTeam(member, "팀이름");
+        Team team = createTeam(member, "팀이름");
         TeamUser teamOwner = teamUserService.findByTeamIdAndUsername(team.getId(), member.getUsername());
 
         Member inviteMember = createMember("removedUser");
@@ -164,7 +164,7 @@ class TeamUserControllerTest {
     void 팀장인_경우_자신을_팀에서_추방_실패() throws Exception {
         // given
         Member member = createMember("testid");
-        TeamResponse.Get team = createTeam(member, "팀이름");
+        Team team = createTeam(member, "팀이름");
 
         // when
         String response = mockMvc.perform(
@@ -184,7 +184,7 @@ class TeamUserControllerTest {
     void 팀장_권한_양도() throws Exception {
         // given
         Member member = createMember("testid");
-        TeamResponse.Get team = createTeam(member, "팀이름");
+        Team team = createTeam(member, "팀이름");
         TeamUser teamOwner = teamUserService.findByTeamIdAndUsername(team.getId(), member.getUsername());
 
         Member inviteMember = createMember("transferUser");
@@ -213,7 +213,7 @@ class TeamUserControllerTest {
     void 팀_탈퇴_성공() throws Exception {
         // given
         Member member = createMember("testid");
-        TeamResponse.Get team = createTeam(member, "팀이름");
+        Team team = createTeam(member, "팀이름");
         TeamUser teamOwner = teamUserService.findByTeamIdAndUsername(team.getId(), member.getUsername());
 
         Member inviteMember = createMember("leaveUser");
@@ -238,7 +238,7 @@ class TeamUserControllerTest {
     void 팀장이_팀_유저_직책_변경() throws Exception {
         // given
         Member member = createMember("testid");
-        TeamResponse.Get team = createTeam(member, "팀이름");
+        Team team = createTeam(member, "팀이름");
         TeamUser teamOwner = teamUserService.findByTeamIdAndUsername(team.getId(), member.getUsername());
 
         Member inviteMember = createMember("changePositionUser");
@@ -259,6 +259,7 @@ class TeamUserControllerTest {
 
         // then
         assertTrue(response.contains("직책이 변경되었습니다."));
+
     }
 
     @WithMockCustomUser(username = "changePositionUser", role = "USER")
@@ -267,7 +268,7 @@ class TeamUserControllerTest {
     void 팀원이_본인_직책_변경() throws Exception {
         // given
         Member member = createMember("testid");
-        TeamResponse.Get team = createTeam(member, "팀이름");
+        Team team = createTeam(member, "팀이름");
         TeamUser teamOwner = teamUserService.findByTeamIdAndUsername(team.getId(), member.getUsername());
 
         Member inviteMember = createMember("changePositionUser");
@@ -296,7 +297,7 @@ class TeamUserControllerTest {
     void 다른_유저가_팀원_직책_변경시도시_실패() throws Exception {
         // given
         Member member = createMember("testid");
-        TeamResponse.Get team = createTeam(member, "팀이름");
+        Team team = createTeam(member, "팀이름");
         TeamUser teamOwner = teamUserService.findByTeamIdAndUsername(team.getId(), member.getUsername());
 
         Member teamMember1 = createMember("user1");
@@ -328,7 +329,7 @@ class TeamUserControllerTest {
     void 팀_소속_유저_추가시_이미_팀에_속했을경우_실패() throws Exception {
         // given
         Member member = createMember("testid");
-        TeamResponse.Get team = createTeam(member, "팀이름");
+        Team team = createTeam(member, "팀이름");
         TeamUser teamOwner = teamUserService.findByTeamIdAndUsername(team.getId(), member.getUsername());
 
         Member inviteMember = createMember("addMember");
@@ -357,7 +358,7 @@ class TeamUserControllerTest {
     void 팀장이_자기_자신을_추방_할_경우_실패() throws Exception {
         // given
         Member member = createMember("testid");
-        TeamResponse.Get team = createTeam(member, "팀이름");
+        Team team = createTeam(member, "팀이름");
 
         String response = mockMvc.perform(
                         delete("/api/team-users/" + member.getUsername() + "?teamId=" + team.getId())


### PR DESCRIPTION
## 📝 작업 내용
- 팀 정보 조회시 팀장의 (owner)의 username을 반환하도록 수정했습니다.

- TeamService에 di를 받아서 
![D07CB807-F60B-4171-A4D2-F690306B674F](https://github.com/Media-XI/artscope-backend/assets/128161745/2384bbb6-f423-4471-86b0-972e99fed240)
(예시 코드입니다)
이런식으로 메서드를 추가해서 리턴해버리면 
1. 변경되는 코드의 수를 줄임
2. team에 대해서 조회하는 쿼리를 줄임 (teamUser을 조회할 때 team은 fetch = fetchType.EAGER로 되어있으므로 해당 방식으로 하면 같은 트랜잭션으로 묶여 영속상태로 team을 가지고 있기 때문에 team을 다시 한번 조회하는걸 줄일 수 있음 )
---
- 하지만 방금 커밋한 방식대로 작업을 했습니다.
그 이유는
1. 각 메서드의 기존보다 행위를 명확하게 했습니다. 

2. 팀이 생성,수정의 행위와 팀을 조회하는 행위가 분리되어야 한다고 생각 했습니다. ( 수정된 response를 받지 못하더라도 team정보는 정상적으로 수정됨)

## 🦾 연관된 이슈
[jirra이슈](https://mediaxi.atlassian.net/jira/software/projects/ART/issues/?jql=project%20%3D%20%22ART%22%20ORDER%20BY%20created%20DESC)

## 💬리뷰 요구사항
해당 수정이 올바른 방향인지. 또한 더 좋은 방법이 있을지 궁금합니다.
